### PR TITLE
Add increased memory limit entitlement for iOS

### DIFF
--- a/swift/AICoven/Resources/AICoven-iOS.entitlements
+++ b/swift/AICoven/Resources/AICoven-iOS.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict/>
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
This PR adds the `com.apple.developer.kernel.increased-memory-limit` entitlement to the iOS app. 

Running local LLMs (even ~2B parameter models) requires significant RAM. iOS strictly terminates apps that exceed their memory footprint limits via Jetsam. Adding this entitlement requests a higher memory ceiling from the OS, which is critical for preventing crashes during model loading and inference on iOS devices.