### PR TITLE
Harden local security phase 1

### DIFF
--- a/swift/AICoven/AICoven/Core/Agents/AgentRunner.swift
+++ b/swift/AICoven/AICoven/Core/Agents/AgentRunner.swift
@@ -62,10 +62,6 @@ final class AgentRunner {
     ) async {
         guard maxSteps > 0 else { return }
 
-        // Configure available tools validation for this agent type
-        // For now, we allow all tools, but this is where we'd set the whitelist
-        // await toolExecutionService.setWhitelist(for: profile.type, tools: ["web_search", "current_time", "file.read"])
-
         let agentGoal = userMessage
         let agentInstruction = """
         You are an autonomous local-first agent running entirely on the user's device.
@@ -91,6 +87,7 @@ final class AgentRunner {
         // Dynamically build the tool config so every connected tool and MCP
         // server is available to the agent by default.
         let toolConfig = await ContextBuilder.ToolConfig.connected()
+        await toolExecutionService.setWhitelist(for: profile.type, tools: toolConfig.enabledTools)
 
         do {
             let run = try await agentRunRepository.createRun(

--- a/swift/AICoven/AICoven/Core/LLM/LLMConfiguration.swift
+++ b/swift/AICoven/AICoven/Core/LLM/LLMConfiguration.swift
@@ -6,30 +6,29 @@ import Foundation
 /// - ModelDescriptors used by ModelRouter.
 /// - Concrete LLMClient implementations, keyed by provider ID.
 ///
-/// API keys are read from UserDefaults via ProviderAccountService's
-/// global cache keys (openai_api_key, anthropic_api_key, gemini_api_key).
-/// Configuration for building LLM clients from user-provided API keys.
-/// All methods are nonisolated since they only read from thread-safe UserDefaults.
+/// API keys are resolved from Keychain via ProviderAccountService account
+/// metadata. UserDefaults is only used for non-secret provider configuration
+/// such as base URLs and model preferences.
 enum LLMConfiguration {
     /// Note: ModelDescriptors are now built dynamically per-account using the
     /// provider's ListModels APIs via ProviderAccountService. This struct only
     /// knows how to build clients; it no longer hardcodes any model IDs.
     /// Builds LLMClient instances for providers that have API keys configured.
-    /// Keys are expected to be cached in UserDefaults by ProviderAccountService.
+    /// Secret keys are read from Keychain using provider account metadata.
     /// This method is implicitly MainActor since it accesses UserScope.
     static func makeDefaultClients() -> [String: LLMClient] {
         var result: [String: LLMClient] = [:]
         let defaults = UserDefaults.standard
 
-        if let openAIKey = defaults.string(forKey: UserScope.scopedKey("openai_api_key")), !openAIKey.isEmpty {
+        if let openAIKey = ProviderAccountService.apiKeyFromKeychain(forProvider: "openai"), !openAIKey.isEmpty {
             result["openai"] = OpenAILLMClient(apiKey: openAIKey)
         }
 
-        if let anthropicKey = defaults.string(forKey: UserScope.scopedKey("anthropic_api_key")), !anthropicKey.isEmpty {
+        if let anthropicKey = ProviderAccountService.apiKeyFromKeychain(forProvider: "anthropic"), !anthropicKey.isEmpty {
             result["anthropic"] = AnthropicLLMClient(apiKey: anthropicKey)
         }
 
-        if let geminiKey = defaults.string(forKey: UserScope.scopedKey("gemini_api_key")), !geminiKey.isEmpty {
+        if let geminiKey = ProviderAccountService.apiKeyFromKeychain(forProvider: "gemini"), !geminiKey.isEmpty {
             result["google"] = GeminiLLMClient(apiKey: geminiKey)
         }
 
@@ -49,12 +48,13 @@ enum LLMConfiguration {
         if let openClawURL = defaults.string(forKey: UserScope.scopedKey("openclaw_base_url")),
            !openClawURL.isEmpty,
            let openClawBaseURL = URL(string: openClawURL) {
-            result["openclaw"] = OpenClawLLMClient(baseURL: openClawBaseURL)
+            let openClawKey = ProviderAccountService.apiKeyFromKeychain(forProvider: "openclaw")
+                ?? ProcessInfo.processInfo.environment["OPENCLAW_API_KEY"]
+            result["openclaw"] = OpenClawLLMClient(baseURL: openClawBaseURL, apiKey: openClawKey)
         }
 
         // Hermes: Nous Research Hermes models via Together AI or self-hosted
-        let hermesKey = defaults.string(forKey: UserScope.scopedKey("hermes_api_key"))
-            ?? defaults.string(forKey: UserScope.scopedKey("together_api_key"))
+        let hermesKey = ProviderAccountService.apiKeyFromKeychain(forProvider: "hermes")
             ?? ProcessInfo.processInfo.environment["HERMES_API_KEY"]
             ?? ProcessInfo.processInfo.environment["TOGETHER_API_KEY"]
         let hermesBaseURL = defaults.string(forKey: UserScope.scopedKey("hermes_base_url"))

--- a/swift/AICoven/AICoven/Core/LLM/PricingUpdateService.swift
+++ b/swift/AICoven/AICoven/Core/LLM/PricingUpdateService.swift
@@ -50,6 +50,36 @@ final class PricingUpdateService {
         }
     }
 
+    /// Clear locally cached provider pricing overrides without touching user
+    /// data, provider credentials, memories, or threads.
+    @discardableResult
+    func clearCachedOverrides() -> Int {
+        var removedItems = 0
+
+        if !cachedOverrides.isEmpty {
+            cachedOverrides = []
+            removedItems += 1
+        }
+
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: lastFetchedKey) != nil {
+            defaults.removeObject(forKey: lastFetchedKey)
+            removedItems += 1
+        }
+
+        let url = cacheURL()
+        if FileManager.default.fileExists(atPath: url.path) {
+            do {
+                try FileManager.default.removeItem(at: url)
+                removedItems += 1
+            } catch {
+                AppErrorReporter.log(error: error, context: "PricingUpdateService.clearCachedOverrides.removeFile")
+            }
+        }
+
+        return removedItems
+    }
+
     #if DEBUG
     /// Testing-only entry point that directly invokes the async refresh logic
     /// without spawning a detached Task. This allows XCTest to await the

--- a/swift/AICoven/AICoven/Core/LLM/Providers/AnthropicLLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/AnthropicLLMClient.swift
@@ -130,8 +130,7 @@ final class AnthropicLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "Anthropic HTTP \(http.statusCode): \(bodyText)"
+            let message = "Anthropic HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "AnthropicLLMClient",
                 code: http.statusCode,

--- a/swift/AICoven/AICoven/Core/LLM/Providers/GeminiLLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/GeminiLLMClient.swift
@@ -162,8 +162,7 @@ final class GeminiLLMClient: LLMClient, @unchecked Sendable {
         // ── Execute request ────────────────────────────────────────────────
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "Gemini HTTP \(http.statusCode): \(bodyText)"
+            let message = "Gemini HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "GeminiLLMClient",
                 code: http.statusCode,
@@ -183,8 +182,7 @@ final class GeminiLLMClient: LLMClient, @unchecked Sendable {
             decoded = try JSONDecoder().decode(ResponseBody.self, from: data)
         } catch {
             #if DEBUG
-            let bodySnippet = String(data: data.prefix(500), encoding: .utf8) ?? "<non-utf8>"
-            AppErrorReporter.log(message: "Gemini decode failed: \(error.localizedDescription)\nResponse: \(bodySnippet)", context: "GeminiLLMClient.completeChat")
+            AppErrorReporter.log(message: "Gemini decode failed: \(error.localizedDescription); response body omitted", context: "GeminiLLMClient.completeChat")
             #endif
             throw error
         }

--- a/swift/AICoven/AICoven/Core/LLM/Providers/HermesLLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/HermesLLMClient.swift
@@ -5,11 +5,12 @@ import Foundation
 /// Hermes is a family of models fine-tuned for agentic capabilities and tool use.
 /// This client supports both Together AI cloud hosting and self-hosted deployments.
 ///
-/// Configuration keys (via UserDefaults):
-/// - hermes_api_key: API key for Together AI or your self-hosted instance
-///   (Alternatively, use together_api_key for Together AI)
+/// Configuration keys:
 /// - hermes_base_url: For self-hosted instances (default: Together AI)
 /// - hermes_model: Model alias or full model ID (default: "hermes-3")
+///
+/// API keys are resolved from Keychain-backed provider accounts, with
+/// HERMES_API_KEY / TOGETHER_API_KEY environment variables as development fallbacks.
 ///
 /// Environment variables:
 /// - HERMES_API_KEY or TOGETHER_API_KEY
@@ -93,10 +94,9 @@ final class HermesLLMClient: LLMClient, @unchecked Sendable {
             ?? ProcessInfo.processInfo.environment["HERMES_BASE_URL"]
         let baseURL = rawBaseURL.flatMap { $0.isEmpty ? nil : URL(string: $0) }
 
-        // Resolve API key (hermes_api_key preferred, fallback to together_api_key)
+        // Resolve API key from Keychain-backed provider accounts, then environment.
         let apiKey = [
-            defaults.string(forKey: UserScope.scopedKey("hermes_api_key")),
-            defaults.string(forKey: UserScope.scopedKey("together_api_key")),
+            ProviderAccountService.apiKeyFromKeychain(forProvider: "hermes"),
             ProcessInfo.processInfo.environment["HERMES_API_KEY"],
             ProcessInfo.processInfo.environment["TOGETHER_API_KEY"]
         ].compactMap(\.self).first(where: { !$0.isEmpty })
@@ -264,8 +264,7 @@ final class HermesLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "Hermes HTTP \(http.statusCode): \(bodyText)"
+            let message = "Hermes HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "HermesLLMClient",
                 code: http.statusCode,
@@ -346,8 +345,7 @@ final class HermesLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "Hermes embeddings HTTP \(http.statusCode): \(bodyText)"
+            let message = "Hermes embeddings HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "HermesLLMClient",
                 code: http.statusCode,

--- a/swift/AICoven/AICoven/Core/LLM/Providers/OllamaLLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/OllamaLLMClient.swift
@@ -83,8 +83,7 @@ final class OllamaLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "Ollama HTTP \(http.statusCode): \(bodyText)"
+            let message = "Ollama HTTP \(http.statusCode). Response body omitted to avoid leaking local model metadata."
             throw NSError(
                 domain: "OllamaLLMClient",
                 code: http.statusCode,
@@ -177,11 +176,10 @@ final class OllamaLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? ""
             throw NSError(
                 domain: "OllamaLLMClient",
                 code: http.statusCode,
-                userInfo: [NSLocalizedDescriptionKey: "Ollama /api/tags HTTP \(http.statusCode): \(bodyText)"]
+                userInfo: [NSLocalizedDescriptionKey: "Ollama embeddings HTTP \(http.statusCode). Response body omitted to avoid leaking local model metadata."]
             )
         }
         let decoded = try JSONDecoder().decode(TagsResponse.self, from: data)

--- a/swift/AICoven/AICoven/Core/LLM/Providers/OpenAILLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/OpenAILLMClient.swift
@@ -132,8 +132,7 @@ final class OpenAILLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "OpenAI HTTP \(http.statusCode): \(bodyText)"
+            let message = "OpenAI HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "OpenAILLMClient",
                 code: http.statusCode,
@@ -201,8 +200,7 @@ final class OpenAILLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "OpenAI embeddings HTTP \(http.statusCode): \(bodyText)"
+            let message = "OpenAI embeddings HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "OpenAILLMClient",
                 code: http.statusCode,

--- a/swift/AICoven/AICoven/Core/LLM/Providers/OpenClawLLMClient.swift
+++ b/swift/AICoven/AICoven/Core/LLM/Providers/OpenClawLLMClient.swift
@@ -5,11 +5,13 @@ import Foundation
 /// OpenClaw is a self-hosted LLM proxy/gateway that presents an OpenAI-compatible API.
 /// This client connects to user-configurable base URLs for local or private deployments.
 ///
-/// Configuration keys (via UserDefaults):
+/// Configuration keys:
 /// - openclaw_base_url: The base URL of your OpenClaw instance (default: http://localhost:3000)
-/// - openclaw_api_key: Optional API key (many local deployments don't require auth)
 /// - openclaw_model: Default model ID to use (optional)
 /// - openclaw_context_tokens: Context window size (default: 4096)
+///
+/// API keys are resolved from Keychain-backed provider accounts, with
+/// OPENCLAW_API_KEY as a development fallback.
 ///
 /// Environment variables:
 /// - OPENCLAW_BASE_URL
@@ -111,8 +113,8 @@ final class OpenClawLLMClient: LLMClient, @unchecked Sendable {
             return nil
         }
 
-        // API key is optional
-        let apiKey: String? = if let key = defaults.string(forKey: UserScope.scopedKey("openclaw_api_key")), !key.isEmpty {
+        // API key is optional and resolved from Keychain-backed provider accounts.
+        let apiKey: String? = if let key = ProviderAccountService.apiKeyFromKeychain(forProvider: "openclaw"), !key.isEmpty {
             key
         } else if let envKey = ProcessInfo.processInfo.environment["OPENCLAW_API_KEY"], !envKey.isEmpty {
             envKey
@@ -234,8 +236,7 @@ final class OpenClawLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "OpenClaw HTTP \(http.statusCode): \(bodyText)"
+            let message = "OpenClaw HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "OpenClawLLMClient",
                 code: http.statusCode,
@@ -314,8 +315,7 @@ final class OpenClawLLMClient: LLMClient, @unchecked Sendable {
 
         let (data, response) = try await urlSession.data(for: request)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-            let bodyText = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-            let message = "OpenClaw embeddings HTTP \(http.statusCode): \(bodyText)"
+            let message = "OpenClaw embeddings HTTP \(http.statusCode). Response body omitted to avoid leaking provider/account metadata."
             throw NSError(
                 domain: "OpenClawLLMClient",
                 code: http.statusCode,

--- a/swift/AICoven/AICoven/Core/Tools/ShellApprovalManager.swift
+++ b/swift/AICoven/AICoven/Core/Tools/ShellApprovalManager.swift
@@ -29,30 +29,17 @@ class ShellApprovalManager: ObservableObject {
     private var pendingContinuations: [UUID: CheckedContinuation<ShellApprovalDecision, Never>] = [:]
 
     /// Built-in patterns that are always auto-approved (read-only operations).
+    /// These are intentionally narrow. Commands with paths, shell metacharacters,
+    /// redirection, pipes, substitutions, or user-added patterns still require
+    /// explicit review unless they pass the same safety guard below.
     /// These are not persisted — they are always present.
     private let builtInAutoApprovePatterns: [String] = [
-        "^ls\\b",
-        "^cat\\b",
-        "^head\\b",
-        "^tail\\b",
-        "^wc\\b",
-        "^grep\\b",
-        "^find\\b",
         "^pwd$",
         "^whoami$",
         "^date$",
-        "^echo\\b",
-        "^git status",
-        "^git log",
-        "^git diff",
-        "^git branch",
-        "^git remote -v",
-        "^which\\b",
-        "^type\\b",
-        "^file\\b",
-        "^stat\\b",
-        "^du\\b",
-        "^df\\b"
+        "^git status( --short)?$",
+        "^git branch( --show-current)?$",
+        "^git remote -v$"
     ]
 
     /// Persistence key for user-added "always allow" patterns.
@@ -140,6 +127,7 @@ class ShellApprovalManager: ObservableObject {
 
     private func isAutoApproved(_ command: String) -> Bool {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isSafeForAutoApproval(trimmed) else { return false }
         for pattern in allAutoApprovePatterns {
             if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
                regex.firstMatch(in: trimmed, options: [], range: NSRange(location: 0, length: trimmed.utf16.count)) != nil {
@@ -147,6 +135,17 @@ class ShellApprovalManager: ObservableObject {
             }
         }
         return false
+    }
+
+    private func isSafeForAutoApproval(_ command: String) -> Bool {
+        let disallowedFragments = [";", "&&", "||", "|", ">", "<", "`", "$(", "${", "\n", "\r"]
+        if disallowedFragments.contains(where: { command.contains($0) }) {
+            return false
+        }
+        let tokens = command.split(whereSeparator: { $0 == " " || $0 == "\t" })
+        return !tokens.contains { token in
+            token.hasPrefix("/") || token.hasPrefix("~") || token.contains("../")
+        }
     }
 
     private func addAutoApprovePattern(_ pattern: String) {

--- a/swift/AICoven/AICoven/Core/Tools/ToolExecutionService.swift
+++ b/swift/AICoven/AICoven/Core/Tools/ToolExecutionService.swift
@@ -811,19 +811,12 @@ actor ToolExecutionService {
     }
 
     private func isToolAllowed(_ toolName: String, for agentType: String) -> Bool {
-        // If no whitelist exists for this agent, deny all (deny-by-default security)
-        // Or change to allow-all if that fits the policy. For now, let's assume if key missing, allow common tools?
-        // Better: require explicit configuration.
-
-        // For Coven agents, we might not have set whitelists yet.
-        // Let's implement a fallback allow-list for basic tools.
         if let allowed = toolWhitelist[agentType] {
             return allowed.contains(toolName)
         }
 
-        // Fallback: allow common tools if no specific profile set
-        // TODO: In production, switch to strict deny-by-default
-        return true
+        // Missing whitelist means no tool is allowed (deny by default).
+        return false
     }
 
     /// Helper to extract typed values from JSON args

--- a/swift/AICoven/AICoven/Features/ConnectedApps/OAuthFlows.swift
+++ b/swift/AICoven/AICoven/Features/ConnectedApps/OAuthFlows.swift
@@ -71,8 +71,8 @@ final class GitHubDeviceFlow: OAuthFlow {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw ConnectedAccountError.oauthFailed(message: "Failed to get device code: \(errorText)")
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw ConnectedAccountError.oauthFailed(message: "Failed to get device code: HTTP \(statusCode). Response body omitted to avoid leaking OAuth metadata.")
         }
 
         // Parse response
@@ -198,11 +198,11 @@ final class GoogleOAuthFlow: NSObject, OAuthFlow, ASWebAuthenticationPresentatio
     /// Start the Google OAuth flow with PKCE
     func authenticate() async throws -> OAuthTokenBundle {
         // Generate PKCE code verifier and challenge
-        codeVerifier = generateCodeVerifier()
+        codeVerifier = try generateCodeVerifier()
         codeChallenge = generateCodeChallenge(verifier: codeVerifier)
 
         // Generate state for CSRF protection
-        let state = UUID().uuidString
+        let state = try generateRandomURLSafeString(byteCount: 16)
 
         // Build authorization URL
         var components = URLComponents(string: "https://accounts.google.com/o/oauth2/v2/auth")!
@@ -276,8 +276,8 @@ final class GoogleOAuthFlow: NSObject, OAuthFlow, ASWebAuthenticationPresentatio
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw ConnectedAccountError.oauthFailed(message: "Token exchange failed: \(errorText)")
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw ConnectedAccountError.oauthFailed(message: "Token exchange failed: HTTP \(statusCode). Response body omitted to avoid leaking OAuth metadata.")
         }
 
         // Parse response
@@ -303,9 +303,16 @@ final class GoogleOAuthFlow: NSObject, OAuthFlow, ASWebAuthenticationPresentatio
     // MARK: - PKCE Helpers
 
     /// Generate a random code verifier for PKCE
-    private func generateCodeVerifier() -> String {
-        var buffer = [UInt8](repeating: 0, count: 32)
-        _ = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+    private func generateCodeVerifier() throws -> String {
+        try generateRandomURLSafeString(byteCount: 32)
+    }
+
+    private func generateRandomURLSafeString(byteCount: Int) throws -> String {
+        var buffer = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+        guard status == errSecSuccess else {
+            throw ConnectedAccountError.oauthFailed(message: "Failed to generate secure OAuth randomness")
+        }
         return Data(buffer).base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")

--- a/swift/AICoven/AICoven/Features/Tools/ShellApprovalView.swift
+++ b/swift/AICoven/AICoven/Features/Tools/ShellApprovalView.swift
@@ -53,6 +53,7 @@ struct ShellApprovalView: View {
             Image(systemName: riskIcon)
                 .font(.system(size: 28))
                 .foregroundColor(riskColor)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Shell Command Approval")
@@ -74,6 +75,7 @@ struct ShellApprovalView: View {
                 .background(riskColor.opacity(0.2))
                 .foregroundColor(riskColor)
                 .cornerRadius(4)
+                .accessibilityLabel("Risk level: \(request.riskLevel.rawValue)")
         }
     }
 
@@ -92,6 +94,8 @@ struct ShellApprovalView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.aicovenGlass)
             .cornerRadius(8)
+            .accessibilityLabel("Command to run")
+            .accessibilityValue(request.command)
         }
     }
 
@@ -114,6 +118,7 @@ struct ShellApprovalView: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: "info.circle")
                 .foregroundColor(.blue)
+                .accessibilityHidden(true)
 
             Text(riskExplanation)
                 .font(.caption)
@@ -135,8 +140,10 @@ struct ShellApprovalView: View {
             TextField("e.g. ^ls\\b or ^git status", text: $customPattern)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.body, design: .monospaced))
+                .accessibilityLabel("Auto-approve regex pattern")
+                .accessibilityHint("Only use narrow read-only command patterns. Unsafe patterns are rejected before approval.")
 
-            Text("Commands matching this pattern will be approved automatically in the future.")
+            Text("Commands matching this pattern will be approved automatically only if they also pass AICoven's shell safety checks.")
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
@@ -160,6 +167,8 @@ struct ShellApprovalView: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(.red)
+                .accessibilityLabel("Deny shell command")
+                .accessibilityHint("Blocks this command from running.")
 
                 // Approve button
                 Button(action: { onDecision(.approve) }) {
@@ -172,6 +181,8 @@ struct ShellApprovalView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.green)
+                .accessibilityLabel("Approve shell command once")
+                .accessibilityHint("Runs this command one time in the displayed working directory.")
             }
 
             // Always approve toggle/button
@@ -188,6 +199,8 @@ struct ShellApprovalView: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(.blue)
+                .accessibilityLabel("Always approve matching safe commands")
+                .accessibilityHint("Saves this regex pattern, but commands must still pass shell safety checks.")
             } else {
                 Button(action: {
                     // Generate a default pattern from the command
@@ -201,6 +214,8 @@ struct ShellApprovalView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.blue)
+                .accessibilityLabel("Create auto-approve pattern")
+                .accessibilityHint("Shows a regex field for defining a narrow safe auto-approval pattern.")
             }
         }
     }

--- a/swift/AICoven/AICoven/Infrastructure/Logging/ErrorReporter.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Logging/ErrorReporter.swift
@@ -17,11 +17,15 @@ struct ConsoleErrorReporter: ErrorReporter {
     private let logger = Logger(subsystem: "dev.aicoven.app", category: "errors")
 
     nonisolated func log(error: Error, context: String) {
-        logger.error("⚠️ [\(context, privacy: .public)] \(error.localizedDescription, privacy: .public)")
+        let safeContext = AppLogRedactor.redact(context)
+        let safeMessage = AppLogRedactor.redact(error.localizedDescription)
+        logger.error("⚠️ [\(safeContext, privacy: .public)] \(safeMessage, privacy: .public)")
     }
 
     nonisolated func log(message: String, context: String) {
-        logger.info("ℹ️ [\(context, privacy: .public)] \(message, privacy: .public)")
+        let safeContext = AppLogRedactor.redact(context)
+        let safeMessage = AppLogRedactor.redact(message)
+        logger.info("ℹ️ [\(safeContext, privacy: .public)] \(safeMessage, privacy: .public)")
     }
 }
 
@@ -45,11 +49,12 @@ enum AppErrorReporter {
 
     /// Log an error. Safe to call from any actor or thread.
     nonisolated static func log(error: Error, context: String) {
-        reporter.log(error: error, context: context)
+        let redactedError = RedactedLoggedError(redactedDescription: AppLogRedactor.redact(error.localizedDescription))
+        reporter.log(error: redactedError, context: AppLogRedactor.redact(context))
     }
 
     /// Log an informational message. Safe to call from any actor or thread.
     nonisolated static func log(message: String, context: String) {
-        reporter.log(message: message, context: context)
+        reporter.log(message: AppLogRedactor.redact(message), context: AppLogRedactor.redact(context))
     }
 }

--- a/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Redacts high-risk secrets and identifiers before they reach console logs,
+/// analytics breadcrumbs, or test reporters.
+enum AppLogRedactor {
+    private static let redaction = "<redacted>"
+
+    /// Return a copy of `message` with sensitive values replaced by a stable
+    /// placeholder. Keep this conservative and deterministic so it is safe to
+    /// use from any logging path.
+    static func redact(_ message: String) -> String {
+        var redacted = message
+
+        let patterns = [
+            // Provider/API tokens and bearer credentials.
+            #"(?i)(authorization\s*[:=]\s*bearer\s+)[A-Za-z0-9._\-+/=]{8,}"#,
+            #"(?i)((api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|secret|password)\s*[:=]\s*)[^\s,;\]\}\)]+"#,
+            #"\b(sk|pk|rk|xox[baprs]|gh[pousr])_[A-Za-z0-9_\-]{12,}\b"#,
+            #"\bAIza[0-9A-Za-z_\-]{20,}\b"#,
+
+            // Email addresses and long opaque IDs commonly found in auth/log output.
+            #"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#,
+            #"(?i)\b(user(uid|id)?|uid|thread(id)?|account(id)?)\s*[:=]\s*['"]?[A-Za-z0-9._\-]{12,}['"]?"#,
+            #"\b[A-Fa-f0-9]{32,}\b"#
+        ]
+
+        for pattern in patterns {
+            redacted = replace(pattern: pattern, in: redacted)
+        }
+
+        return redacted
+    }
+
+    private static func replace(pattern: String, in text: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        let range = NSRange(location: 0, length: (text as NSString).length)
+        return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: redaction)
+    }
+}
+
+/// Error wrapper used by AppErrorReporter after redaction.
+struct RedactedLoggedError: LocalizedError, CustomStringConvertible {
+    let redactedDescription: String
+
+    var errorDescription: String? { redactedDescription }
+    var description: String { redactedDescription }
+}

--- a/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
@@ -14,7 +14,7 @@ enum AppLogRedactor {
         let patterns = [
             // Provider/API tokens and bearer credentials.
             #"(?i)(authorization\s*[:=]\s*bearer\s+)[A-Za-z0-9._\-+/=]{8,}"#,
-            #"(?i)((api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|secret|password)\s*[:=]\s*)[^\s,;\]\}\)]+"#,
+            #"(?i)((api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password)\s*[:=]\s*)[^\s,;\]\}\)]+"#,
             #"\b(sk|pk|rk|xox[baprs]|gh[pousr])_[A-Za-z0-9_\-]{12,}\b"#,
             #"\bAIza[0-9A-Za-z_\-]{20,}\b"#,
 

--- a/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Logging/LogRedactor.swift
@@ -42,6 +42,11 @@ enum AppLogRedactor {
 struct RedactedLoggedError: LocalizedError, CustomStringConvertible {
     let redactedDescription: String
 
-    var errorDescription: String? { redactedDescription }
-    var description: String { redactedDescription }
+    var errorDescription: String? {
+        redactedDescription
+    }
+
+    var description: String {
+        redactedDescription
+    }
 }

--- a/swift/AICoven/AICoven/Infrastructure/Persistence/CovenRecord.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Persistence/CovenRecord.swift
@@ -201,7 +201,7 @@ actor CovenRepository {
 
         let now = Date()
         let id = UUID().uuidString
-        let uid = await UserScope.currentUserID
+        let uid = UserScope.currentUserID
         let record = CovenRecord(
             id: id,
             name: name,
@@ -232,7 +232,7 @@ actor CovenRepository {
         guard let dbQueue = await getDbQueue() else { throw RepositoryError.databaseUnavailable }
 
         // Fetch user ID outside the synchronous database closure
-        let uid = await UserScope.currentUserID
+        let uid = UserScope.currentUserID
 
         let records: [CovenRecord] = try await dbQueue.read { db in
             var request = CovenRecord.order(CovenRecord.Columns.createdAt.desc)
@@ -298,7 +298,7 @@ actor CovenRepository {
         guard let dbQueue = await getDbQueue() else { throw RepositoryError.databaseUnavailable }
 
         // Fetch user ID outside the synchronous database closure
-        let uid = await UserScope.currentUserID
+        let uid = UserScope.currentUserID
 
         let records: [RoleRecord] = try await dbQueue.read { db in
             var request = RoleRecord

--- a/swift/AICoven/AICoven/Infrastructure/Persistence/CovenRecord.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Persistence/CovenRecord.swift
@@ -201,7 +201,7 @@ actor CovenRepository {
 
         let now = Date()
         let id = UUID().uuidString
-        let uid = UserScope.currentUserID
+        let uid = await UserScope.currentUserID
         let record = CovenRecord(
             id: id,
             name: name,
@@ -232,14 +232,13 @@ actor CovenRepository {
         guard let dbQueue = await getDbQueue() else { throw RepositoryError.databaseUnavailable }
 
         // Fetch user ID outside the synchronous database closure
-        let uid = UserScope.currentUserID
+        let uid = await UserScope.currentUserID
 
         let records: [CovenRecord] = try await dbQueue.read { db in
-            var request = CovenRecord.order(CovenRecord.Columns.createdAt.desc)
-            if let uid {
-                request = request.filter(CovenRecord.Columns.userId == uid)
-            }
-            return try request.fetchAll(db)
+            try CovenRecord
+                .filter(CovenRecord.Columns.userId == uid)
+                .order(CovenRecord.Columns.createdAt.desc)
+                .fetchAll(db)
         }
 
         return records.map { rec in
@@ -298,16 +297,14 @@ actor CovenRepository {
         guard let dbQueue = await getDbQueue() else { throw RepositoryError.databaseUnavailable }
 
         // Fetch user ID outside the synchronous database closure
-        let uid = UserScope.currentUserID
+        let uid = await UserScope.currentUserID
 
         let records: [RoleRecord] = try await dbQueue.read { db in
-            var request = RoleRecord
+            try RoleRecord
                 .filter(RoleRecord.Columns.covenId == covenId)
+                .filter(RoleRecord.Columns.userId == uid)
                 .order(RoleRecord.Columns.createdAt.asc)
-            if let uid {
-                request = request.filter(RoleRecord.Columns.userId == uid)
-            }
-            return try request.fetchAll(db)
+                .fetchAll(db)
         }
 
         return records.map { mapRecordToRole($0) }

--- a/swift/AICoven/AICoven/Infrastructure/Persistence/DatabaseManager.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Persistence/DatabaseManager.swift
@@ -45,7 +45,9 @@ final class DatabaseManager {
         guard dbQueue == nil else { return }
 
         do {
-            let queue = try DatabaseQueue(path: databaseURL.path)
+            var configuration = Configuration()
+            configuration.foreignKeysEnabled = true
+            let queue = try DatabaseQueue(path: databaseURL.path, configuration: configuration)
             var migrator = DatabaseMigrator()
 
             migrator.registerMigration("v1_schema") { db in
@@ -205,6 +207,80 @@ final class DatabaseManager {
                 try db.create(index: "messages_user_id", on: "messages", columns: ["user_id"])
                 try db.create(index: "memory_chunks_user_id", on: "memory_chunks", columns: ["user_id"])
                 try db.create(index: "memory_proposals_user_id", on: "memory_proposals", columns: ["user_id"])
+            }
+
+            // v6: enforce local user isolation at the database boundary.
+            // Existing v4/v5 migrations added nullable user_id columns for compatibility;
+            // triggers below fail closed for all future inserts/updates and prevent
+            // child rows from referencing a parent owned by a different user.
+            migrator.registerMigration("v6_user_isolation_guards") { db in
+                for table in ["covens", "roles", "threads", "messages", "memory_chunks", "memory_proposals"] {
+                    try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS \(table)_require_user_id_insert
+                    BEFORE INSERT ON \(table)
+                    WHEN NEW.user_id IS NULL OR length(trim(NEW.user_id)) = 0
+                    BEGIN
+                        SELECT RAISE(ABORT, '\(table).user_id is required');
+                    END;
+                    """)
+                    try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS \(table)_require_user_id_update
+                    BEFORE UPDATE OF user_id ON \(table)
+                    WHEN NEW.user_id IS NULL OR length(trim(NEW.user_id)) = 0
+                    BEGIN
+                        SELECT RAISE(ABORT, '\(table).user_id is required');
+                    END;
+                    """)
+                }
+
+                try db.create(index: "roles_user_coven", on: "roles", columns: ["user_id", "coven_id"])
+                try db.create(index: "messages_user_thread", on: "messages", columns: ["user_id", "thread_id"])
+
+                try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS roles_match_coven_user_insert
+                BEFORE INSERT ON roles
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM covens
+                    WHERE covens.id = NEW.coven_id AND covens.user_id = NEW.user_id
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'roles.coven_id must reference a coven owned by the same user');
+                END;
+                """)
+                try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS roles_match_coven_user_update
+                BEFORE UPDATE OF user_id, coven_id ON roles
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM covens
+                    WHERE covens.id = NEW.coven_id AND covens.user_id = NEW.user_id
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'roles.coven_id must reference a coven owned by the same user');
+                END;
+                """)
+
+                try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS messages_match_thread_user_insert
+                BEFORE INSERT ON messages
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM threads
+                    WHERE threads.id = NEW.thread_id AND threads.user_id = NEW.user_id
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'messages.thread_id must reference a thread owned by the same user');
+                END;
+                """)
+                try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS messages_match_thread_user_update
+                BEFORE UPDATE OF user_id, thread_id ON messages
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM threads
+                    WHERE threads.id = NEW.thread_id AND threads.user_id = NEW.user_id
+                )
+                BEGIN
+                    SELECT RAISE(ABORT, 'messages.thread_id must reference a thread owned by the same user');
+                END;
+                """)
             }
 
             try migrator.migrate(queue)

--- a/swift/AICoven/AICoven/Infrastructure/Security/DataEncryptionService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Security/DataEncryptionService.swift
@@ -38,8 +38,7 @@ actor DataEncryptionService {
     private let keychainService = "com.aicoven.local.encryption"
     /// User-scoped Keychain account for device passphrase isolation.
     private var keychainAccount: String {
-        guard let uid = UserScope.currentUserID else { return "device_passphrase" }
-        return "device_passphrase_\(uid)"
+        "device_passphrase_\(UserScope.currentUserID)"
     }
 
     /// Cached in-memory data-encryption key (K_data) for the current session.

--- a/swift/AICoven/AICoven/Infrastructure/Security/DataEncryptionService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Security/DataEncryptionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CommonCrypto
 import CryptoKit
 import LocalAuthentication
 import Security
@@ -21,6 +22,12 @@ actor DataEncryptionService {
     private struct Metadata: Codable {
         let salt: Data
         let wrappedKey: Data
+        let kdfVersion: Int?
+    }
+
+    private enum KDFVersion {
+        static let pbkdf2SHA256 = 2
+        static let pbkdf2Rounds = 210_000
     }
 
     /// User-scoped metadata key so each Firebase user has independent encryption.
@@ -46,14 +53,25 @@ actor DataEncryptionService {
     /// provided passphrase. Must be called before encrypt/decrypt.
     func unlock(withPassphrase passphrase: String) throws {
         if let metadata = try loadMetadata() {
-            let kWrap = try deriveWrappingKey(from: passphrase, salt: metadata.salt)
-            let sealedBox = try AES.GCM.SealedBox(combined: metadata.wrappedKey)
-            let kDataBytes = try AES.GCM.open(sealedBox, using: kWrap)
+            let kDataBytes: Data
+            if metadata.kdfVersion == KDFVersion.pbkdf2SHA256 {
+                let kWrap = try deriveWrappingKey(from: passphrase, salt: metadata.salt)
+                let sealedBox = try AES.GCM.SealedBox(combined: metadata.wrappedKey)
+                kDataBytes = try AES.GCM.open(sealedBox, using: kWrap)
+            } else {
+                // Legacy metadata used HKDF directly over the passphrase. Keep
+                // a read path so existing local installs can unlock, then
+                // immediately re-wrap under PBKDF2 metadata.
+                let legacyWrap = deriveLegacyHKDFWrappingKey(from: passphrase, salt: metadata.salt)
+                let sealedBox = try AES.GCM.SealedBox(combined: metadata.wrappedKey)
+                kDataBytes = try AES.GCM.open(sealedBox, using: legacyWrap)
+                try rewrapDataKey(kDataBytes, passphrase: passphrase)
+            }
             cachedDataKey = SymmetricKey(data: kDataBytes)
         } else {
             // First-time setup: generate K_data and metadata.
             let kData = SymmetricKey(size: .bits256)
-            let salt = Data((0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) })
+            let salt = try secureRandomData(byteCount: 32)
             let kWrap = try deriveWrappingKey(from: passphrase, salt: salt)
 
             let kDataBytes = kData.withUnsafeBytes { Data($0) }
@@ -62,7 +80,7 @@ actor DataEncryptionService {
                 throw NSError(domain: "DataEncryptionService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to wrap data key"])
             }
 
-            let metadata = Metadata(salt: salt, wrappedKey: combined)
+            let metadata = Metadata(salt: salt, wrappedKey: combined, kdfVersion: KDFVersion.pbkdf2SHA256)
             try storeMetadata(metadata)
             cachedDataKey = kData
         }
@@ -108,8 +126,7 @@ actor DataEncryptionService {
         } else {
             // First-time setup: generate a random passphrase that never leaves
             // the device and is stored only in the Keychain.
-            let randomBytes = (0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) }
-            let passphrase = Data(randomBytes).base64EncodedString()
+            let passphrase = try secureRandomData(byteCount: 32).base64EncodedString()
             try storeDevicePassphraseInKeychain(passphrase)
             try unlock(withPassphrase: passphrase)
         }
@@ -146,10 +163,42 @@ actor DataEncryptionService {
         return key
     }
 
-    /// Derives K_wrap from a passphrase and salt.
-    /// NOTE: This uses a simple HKDF-based derivation for now. For
-    /// production, consider a PBKDF2/Argon2-based KDF tuned per device.
+    /// Derives K_wrap from a passphrase and salt using PBKDF2-HMAC-SHA256.
+    /// The iteration count is intentionally stored in code as the current local
+    /// security baseline; future upgrades should bump `kdfVersion` and migrate
+    /// on successful unlock.
     private func deriveWrappingKey(from passphrase: String, salt: Data) throws -> SymmetricKey {
+        guard let passwordData = passphrase.data(using: .utf8) else {
+            throw NSError(domain: "DataEncryptionService", code: -20, userInfo: [NSLocalizedDescriptionKey: "Invalid passphrase encoding"])
+        }
+
+        var derivedKey = Data(repeating: 0, count: 32)
+        let derivedKeyLength = derivedKey.count
+        let status = derivedKey.withUnsafeMutableBytes { derivedBytes in
+            salt.withUnsafeBytes { saltBytes in
+                passwordData.withUnsafeBytes { passwordBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        passwordData.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(KDFVersion.pbkdf2Rounds),
+                        derivedBytes.bindMemory(to: UInt8.self).baseAddress,
+                        derivedKeyLength
+                    )
+                }
+            }
+        }
+
+        guard status == kCCSuccess else {
+            throw NSError(domain: "DataEncryptionService", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to derive encryption key"])
+        }
+        return SymmetricKey(data: derivedKey)
+    }
+
+    private func deriveLegacyHKDFWrappingKey(from passphrase: String, salt: Data) -> SymmetricKey {
         let inputKey = SymmetricKey(data: Data(passphrase.utf8))
         return HKDF<SHA256>.deriveKey(
             inputKeyMaterial: inputKey,
@@ -157,6 +206,25 @@ actor DataEncryptionService {
             info: Data("aicoven-local-wrap".utf8),
             outputByteCount: 32
         )
+    }
+
+    private func rewrapDataKey(_ kDataBytes: Data, passphrase: String) throws {
+        let salt = try secureRandomData(byteCount: 32)
+        let kWrap = try deriveWrappingKey(from: passphrase, salt: salt)
+        let sealed = try AES.GCM.seal(kDataBytes, using: kWrap)
+        guard let combined = sealed.combined else {
+            throw NSError(domain: "DataEncryptionService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to wrap data key"])
+        }
+        try storeMetadata(Metadata(salt: salt, wrappedKey: combined, kdfVersion: KDFVersion.pbkdf2SHA256))
+    }
+
+    private func secureRandomData(byteCount: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw NSError(domain: "DataEncryptionService", code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to generate secure random data"])
+        }
+        return Data(bytes)
     }
 
     private func loadMetadata() throws -> Metadata? {

--- a/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
@@ -70,8 +70,9 @@ actor GitHubToolService {
 
     /// Parse GitHub error response into actionable message
     private func parseError(statusCode: Int, data: Data, context: String) -> GitHubError {
-        let message: String = if let apiError = try? JSONDecoder().decode(GitHubAPIError.self, from: data) {
-            apiError.message
+        let message: String = if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                                 let apiMessage = json["message"] as? String {
+            apiMessage
         } else {
             "HTTP \(statusCode). Response body omitted to avoid leaking connected-account metadata."
         }

--- a/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
@@ -70,8 +70,7 @@ actor GitHubToolService {
 
     /// Parse GitHub error response into actionable message
     private func parseError(statusCode: Int, data: Data, context: String) -> GitHubError {
-        let message: String = if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let errorMessage = if let apiError = try? JSONDecoder().decode(GitHubAPIError.self, from: data) {
+        let message: String = if let apiError = try? JSONDecoder().decode(GitHubAPIError.self, from: data) {
             apiError.message
         } else {
             "HTTP \(statusCode). Response body omitted to avoid leaking connected-account metadata."

--- a/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/GitHubToolService.swift
@@ -71,10 +71,10 @@ actor GitHubToolService {
     /// Parse GitHub error response into actionable message
     private func parseError(statusCode: Int, data: Data, context: String) -> GitHubError {
         let message: String = if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                                 let msg = json["message"] as? String {
-            msg
+        let errorMessage = if let apiError = try? JSONDecoder().decode(GitHubAPIError.self, from: data) {
+            apiError.message
         } else {
-            String(data: data, encoding: .utf8) ?? "Unknown error"
+            "HTTP \(statusCode). Response body omitted to avoid leaking connected-account metadata."
         }
 
         switch statusCode {

--- a/swift/AICoven/AICoven/Infrastructure/Tools/GoogleDriveToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/GoogleDriveToolService.swift
@@ -71,7 +71,7 @@ actor GoogleDriveToolService {
            let message = error["message"] as? String {
             return .apiError(statusCode: statusCode, message: message)
         }
-        return .apiError(statusCode: statusCode, message: String(data: data, encoding: .utf8) ?? "Unknown error")
+        return .apiError(statusCode: statusCode, message: "HTTP \(statusCode). Response body omitted to avoid leaking connected-account metadata.")
     }
 
     // MARK: - Drive Operations

--- a/swift/AICoven/AICoven/Infrastructure/Tools/ShellToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/ShellToolService.swift
@@ -101,7 +101,7 @@ actor ShellToolService {
         // and always prompts for medium/high risk commands.
         let decision = await requestApproval(
             command: command,
-            workingDir: workingDir,
+            workingDir: normalizedWorkingDir,
             riskLevel: riskLevel,
             metadata: metadata
         )

--- a/swift/AICoven/AICoven/Infrastructure/Tools/ShellToolService.swift
+++ b/swift/AICoven/AICoven/Infrastructure/Tools/ShellToolService.swift
@@ -65,6 +65,25 @@ actor ShellToolService {
     ) async -> ToolExecutionResult {
         let timeout = timeoutSeconds ?? defaultTimeoutSeconds
 
+        guard let normalizedWorkingDir = normalizeWorkingDirectory(workingDir), !normalizedWorkingDir.isEmpty else {
+            return await .permissionDenied(
+                tool: "shell.execute",
+                message: "Shell commands must include an explicit working directory.",
+                helpfulInstructions: "Choose a user-authorized project folder and retry with workingDir set."
+            )
+        }
+
+        let directoryAccessible = await MainActor.run {
+            FileAccessManager.shared.isPathAccessible(normalizedWorkingDir)
+        }
+        guard directoryAccessible else {
+            return await .permissionDenied(
+                tool: "shell.execute",
+                message: "Shell working directory '\(normalizedWorkingDir)' is not authorized.",
+                helpfulInstructions: "Grant access in Settings > File Access before running shell commands there."
+            )
+        }
+
         // Check if command is blocked
         if isCommandBlocked(command) {
             return await .permissionDenied(
@@ -97,7 +116,7 @@ actor ShellToolService {
         // Execute the command
         return await executeCommand(
             command: command,
-            workingDir: workingDir,
+            workingDir: normalizedWorkingDir,
             env: env,
             timeoutSeconds: timeout
         )
@@ -114,6 +133,15 @@ actor ShellToolService {
             }
         }
         return false
+    }
+
+    /// Normalize and resolve the shell working directory before authorization.
+    private func normalizeWorkingDirectory(_ workingDir: String?) -> String? {
+        guard let workingDir, !workingDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        let expanded = (workingDir as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     /// Request user approval for a command.

--- a/swift/AICoven/AICoven/Infrastructure/UserScope.swift
+++ b/swift/AICoven/AICoven/Infrastructure/UserScope.swift
@@ -7,18 +7,29 @@ import FirebaseCore
 ///
 /// Every service that persists user-specific data should use these helpers
 /// so that signing in as a different user produces a completely isolated
-/// data space.
+/// data space. Local/offline mode uses an explicit stable local user scope;
+/// it must never fall back to unscoped keys.
 enum UserScope {
 
     // MARK: - Current User
 
-    /// The Firebase UID of the currently signed-in user, or `nil` if
-    /// nobody is signed in or Firebase is not configured.
-    static var currentUserID: String? {
+    /// Stable owner ID for local-first/offline use when Firebase is unavailable
+    /// or no Firebase user is signed in.
+    static let localUserID = "local-user"
+
+    /// The Firebase UID of the currently signed-in user, if Firebase is configured.
+    static var firebaseUserID: String? {
         // Guard against accessing Auth before Firebase is configured
         // (crashes in CI/test environments without valid GoogleService-Info.plist)
         guard FirebaseApp.app() != nil else { return nil }
         return Auth.auth().currentUser?.uid
+    }
+
+    /// The owner ID that must be used for all local persistence. This always
+    /// returns either the authenticated Firebase UID or the explicit local user
+    /// scope; returning an unscoped nil would leak data across auth states.
+    static var currentUserID: String {
+        firebaseUserID ?? localUserID
     }
 
     // MARK: - Key Scoping
@@ -26,18 +37,13 @@ enum UserScope {
     /// Returns a UserDefaults key scoped to the current user.
     ///
     /// Example: `scopedKey("provider_accounts.v1")` → `"abc123.provider_accounts.v1"`
-    ///
-    /// Falls back to the unscoped `base` if no user is signed in, so the
-    /// app doesn't crash when accessed before authentication.
     static func scopedKey(_ base: String) -> String {
-        guard let uid = currentUserID else { return base }
-        return "\(uid).\(base)"
+        "\(currentUserID).\(base)"
     }
 
     /// Returns a Keychain service identifier scoped to the current user.
     static func scopedKeychainService(_ base: String) -> String {
-        guard let uid = currentUserID else { return base }
-        return "\(base).\(uid)"
+        "\(base).\(currentUserID)"
     }
 
     /// Returns a filename scoped to the current user.
@@ -45,7 +51,6 @@ enum UserScope {
     /// Example: `scopedFilename("personal_threads", extension: "json")` →
     /// `"personal_threads_abc123.json"`
     static func scopedFilename(_ base: String, extension ext: String) -> String {
-        guard let uid = currentUserID else { return "\(base).\(ext)" }
-        return "\(base)_\(uid).\(ext)"
+        "\(base)_\(currentUserID).\(ext)"
     }
 }

--- a/swift/AICoven/AICoven/Services/AuthService.swift
+++ b/swift/AICoven/AICoven/Services/AuthService.swift
@@ -29,7 +29,6 @@ class AuthService: ObservableObject {
     private static func onboardingKey(for uid: String? = nil) -> String {
         let id = uid ?? UserScope.currentUserID
         let base = "hasCompletedOnboarding"
-        guard let id else { return base }
         return "\(id).\(base)"
     }
 

--- a/swift/AICoven/AICoven/Services/CacheManagementService.swift
+++ b/swift/AICoven/AICoven/Services/CacheManagementService.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct CacheClearResult: Equatable {
+    let removedItems: Int
+
+    var userMessage: String {
+        if removedItems == 0 {
+            return "No cached files needed clearing."
+        }
+        return "Cleared local cache. Your chats, memories, and provider keys were not changed."
+    }
+}
+
+/// Clears disposable local caches only. This intentionally does not remove
+/// user-authored data, encrypted databases, provider credentials, memories, or
+/// thread JSON stores.
+enum CacheManagementService {
+    @discardableResult
+    static func clearLocalCaches() -> CacheClearResult {
+        URLCache.shared.removeAllCachedResponses()
+        let removedItems = PricingUpdateService.shared.clearCachedOverrides()
+        AppErrorReporter.log(message: "Cleared disposable local caches", context: "CacheManagementService.clearLocalCaches")
+        return CacheClearResult(removedItems: removedItems)
+    }
+}

--- a/swift/AICoven/AICoven/Services/ChatService.swift
+++ b/swift/AICoven/AICoven/Services/ChatService.swift
@@ -471,6 +471,7 @@ actor ChatService {
         let toolConfig: ContextBuilder.ToolConfig = isLocalModel
             ? await .mlxTools()
             : await .connected()
+        await ToolExecutionService.shared.setWhitelist(for: "chat", tools: toolConfig.enabledTools)
 
         // ── Context-aware repeat detection (ported from backend) ──────────
         // Tracks tool-call signatures across loop iterations so we can

--- a/swift/AICoven/AICoven/Services/ChatService.swift
+++ b/swift/AICoven/AICoven/Services/ChatService.swift
@@ -1494,6 +1494,8 @@ private extension LocalChatError {
         switch self {
         case .missingOpenAIAPIKey:
             "missing_openai_api_key"
+        case .missingAPIKey:
+            "missing_api_key"
         case .missingBaseURL:
             "missing_base_url"
         case .invalidResponse:

--- a/swift/AICoven/AICoven/Services/LLMClients.swift
+++ b/swift/AICoven/AICoven/Services/LLMClients.swift
@@ -5,13 +5,16 @@ import Foundation
 /// Errors specific to local chat orchestration
 enum LocalChatError: Error, LocalizedError {
     case missingOpenAIAPIKey
+    case missingAPIKey(provider: String)
     case missingBaseURL
     case invalidResponse
 
     var errorDescription: String? {
         switch self {
         case .missingOpenAIAPIKey:
-            "No API key configured. Set the appropriate environment variable or store the key in UserDefaults."
+            "No OpenAI API key configured. Add an OpenAI provider account or set OPENAI_API_KEY."
+        case let .missingAPIKey(provider):
+            "No \(provider) API key configured. Add a \(provider) provider account or set the provider-specific environment variable."
         case .missingBaseURL:
             "No base URL configured. Set the appropriate base URL in UserDefaults."
         case .invalidResponse:
@@ -138,7 +141,7 @@ private actor AnthropicClient {
         if let env = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !env.isEmpty {
             return env
         }
-        throw LocalChatError.missingOpenAIAPIKey
+        throw LocalChatError.missingAPIKey(provider: "Anthropic")
     }
 
     func sendChat(
@@ -241,7 +244,7 @@ private actor GeminiClient {
         if let env = ProcessInfo.processInfo.environment["GEMINI_API_KEY"], !env.isEmpty {
             return env
         }
-        throw LocalChatError.missingOpenAIAPIKey
+        throw LocalChatError.missingAPIKey(provider: "Gemini")
     }
 
     func sendChat(

--- a/swift/AICoven/AICoven/Services/LLMClients.swift
+++ b/swift/AICoven/AICoven/Services/LLMClients.swift
@@ -41,10 +41,10 @@ private struct WireLLMMessage: Encodable {
 private actor OpenAIClient {
     private let apiURL = URL(string: "https://api.openai.com/v1/chat/completions")!
 
-    /// Resolve API key from either UserDefaults ("openai_api_key") or the
+    /// Resolve API key from Keychain-backed provider accounts or the
     /// OPENAI_API_KEY environment variable.
     private func apiKey() throws -> String {
-        if let key = UserDefaults.standard.string(forKey: UserScope.scopedKey("openai_api_key")), !key.isEmpty {
+        if let key = ProviderAccountService.apiKeyFromKeychain(forProvider: "openai"), !key.isEmpty {
             return key
         }
         if let env = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !env.isEmpty {
@@ -102,8 +102,7 @@ private actor OpenAIClient {
 
         let (responseData, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
-            let bodyText = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
-            AppErrorReporter.log(message: "OpenAI error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1) body=\(bodyText)", context: "LLMClients.OpenAIClient.sendChat")
+            AppErrorReporter.log(message: "OpenAI error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1); response body omitted", context: "LLMClients.OpenAIClient.sendChat")
             throw LocalChatError.invalidResponse
         }
 
@@ -133,7 +132,7 @@ private actor AnthropicClient {
     private let apiURL = URL(string: "https://api.anthropic.com/v1/messages")!
 
     private func apiKey() throws -> String {
-        if let key = UserDefaults.standard.string(forKey: UserScope.scopedKey("anthropic_api_key")), !key.isEmpty {
+        if let key = ProviderAccountService.apiKeyFromKeychain(forProvider: "anthropic"), !key.isEmpty {
             return key
         }
         if let env = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !env.isEmpty {
@@ -211,8 +210,7 @@ private actor AnthropicClient {
 
         let (responseData, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
-            let bodyText = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
-            AppErrorReporter.log(message: "Anthropic error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1) body=\(bodyText)", context: "LLMClients.AnthropicClient.sendChat")
+            AppErrorReporter.log(message: "Anthropic error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1); response body omitted", context: "LLMClients.AnthropicClient.sendChat")
             throw LocalChatError.invalidResponse
         }
 
@@ -237,7 +235,7 @@ private actor GeminiClient {
     private let baseURL = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/")!
 
     private func apiKey() throws -> String {
-        if let key = UserDefaults.standard.string(forKey: UserScope.scopedKey("gemini_api_key")), !key.isEmpty {
+        if let key = ProviderAccountService.apiKeyFromKeychain(forProvider: "gemini"), !key.isEmpty {
             return key
         }
         if let env = ProcessInfo.processInfo.environment["GEMINI_API_KEY"], !env.isEmpty {
@@ -295,8 +293,7 @@ private actor GeminiClient {
 
         let (responseData, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
-            let bodyText = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
-            AppErrorReporter.log(message: "Gemini error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1) body=\(bodyText)", context: "LLMClients.GeminiClient.sendChat")
+            AppErrorReporter.log(message: "Gemini error: status=\((response as? HTTPURLResponse)?.statusCode ?? -1); response body omitted", context: "LLMClients.GeminiClient.sendChat")
             throw LocalChatError.invalidResponse
         }
 

--- a/swift/AICoven/AICoven/Services/ProviderAccountService.swift
+++ b/swift/AICoven/AICoven/Services/ProviderAccountService.swift
@@ -522,8 +522,8 @@ extension ProviderAccountService {
             if normalized == "google" || normalized == "gemini" {
                 return lower == "google" || lower == "gemini"
             }
-            if normalized == "together" {
-                return lower == "hermes"
+            if normalized == "hermes" || normalized == "together" {
+                return lower == "hermes" || lower == "together"
             }
             return lower == normalized
         }

--- a/swift/AICoven/AICoven/Services/ProviderAccountService.swift
+++ b/swift/AICoven/AICoven/Services/ProviderAccountService.swift
@@ -537,20 +537,19 @@ extension ProviderAccountService {
 
     static func clearLegacyAPIKeyCache(provider: String) {
         let defaults = UserDefaults.standard
-        let keys: [String]
-        switch provider.lowercased() {
+        let keys: [String] = switch provider.lowercased() {
         case "openai":
-            keys = ["openai_api_key"]
+            ["openai_api_key"]
         case "anthropic":
-            keys = ["anthropic_api_key"]
+            ["anthropic_api_key"]
         case "google", "gemini":
-            keys = ["gemini_api_key"]
+            ["gemini_api_key"]
         case "openclaw":
-            keys = ["openclaw_api_key"]
+            ["openclaw_api_key"]
         case "hermes", "together":
-            keys = ["hermes_api_key", "together_api_key"]
+            ["hermes_api_key", "together_api_key"]
         default:
-            keys = []
+            []
         }
         for key in keys {
             defaults.removeObject(forKey: UserScope.scopedKey(key))

--- a/swift/AICoven/AICoven/Services/ProviderAccountService.swift
+++ b/swift/AICoven/AICoven/Services/ProviderAccountService.swift
@@ -64,6 +64,7 @@ enum KeychainHelper {
         SecItemDelete(query as CFDictionary)
         var attributes = query
         attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         let status = SecItemAdd(attributes as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw NSError(domain: NSOSStatusErrorDomain, code: Int(status))
@@ -100,9 +101,9 @@ enum KeychainHelper {
 /// in the local-only client.
 ///
 /// Accounts are stored as JSON in UserDefaults (without secrets). Raw API
-/// keys are stored in the system Keychain, keyed by provider-account ID. For
-/// compatibility with the existing ChatService, we also mirror the most
-/// recent key per provider into UserDefaults (e.g. "openai_api_key").
+/// keys are stored in the system Keychain, keyed by provider-account ID.
+/// UserDefaults may hold non-secret provider configuration such as base URLs
+/// and model preferences, but it must never mirror raw API keys.
 actor ProviderAccountService {
     static let shared = ProviderAccountService()
 
@@ -146,10 +147,11 @@ actor ProviderAccountService {
         locals.append(local)
         try saveLocalAccounts(locals)
 
-        // Store the API key in the Keychain, and mirror to UserDefaults so the
-        // existing ChatService clients (OpenAI/Anthropic/Gemini) can read it.
+        // Store the API key in the Keychain only. Never mirror raw provider
+        // credentials into UserDefaults; LLMConfiguration resolves them from
+        // Keychain using the stored account metadata.
         try KeychainHelper.save(key: keychainKey(for: id), value: apiKey)
-        updateGlobalAPIKeyCache(provider: provider, apiKey: apiKey, baseURL: nil)
+        clearLegacyAPIKeyCache(provider: provider)
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
 
@@ -180,8 +182,8 @@ actor ProviderAccountService {
         locals.append(local)
         try saveLocalAccounts(locals)
 
-        // Cache base URL so LLMConfiguration can build the OllamaLLMClient.
-        updateGlobalAPIKeyCache(provider: "ollama", apiKey: nil, baseURL: baseURL)
+        // Cache non-secret base URL so LLMConfiguration can build the OllamaLLMClient.
+        updateProviderConfigCache(provider: "ollama", baseURL: baseURL)
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
 
@@ -249,7 +251,8 @@ actor ProviderAccountService {
             try KeychainHelper.save(key: keychainKey(for: id), value: apiKey)
         }
 
-        updateGlobalAPIKeyCache(provider: "openclaw", apiKey: apiKey, baseURL: baseURL)
+        updateProviderConfigCache(provider: "openclaw", baseURL: baseURL)
+        clearLegacyAPIKeyCache(provider: "openclaw")
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
 
@@ -284,7 +287,8 @@ actor ProviderAccountService {
             try KeychainHelper.save(key: keychainKey(for: id), value: apiKey)
         }
 
-        updateGlobalAPIKeyCache(provider: "hermes", apiKey: apiKey, baseURL: baseURL)
+        updateProviderConfigCache(provider: "hermes", baseURL: baseURL)
+        clearLegacyAPIKeyCache(provider: "hermes")
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
 
@@ -317,15 +321,15 @@ actor ProviderAccountService {
         locals[index] = updated
         try saveLocalAccounts(locals)
 
-        // Update Keychain if API key changed
+        // Update Keychain if API key changed. Do not mirror secrets into UserDefaults.
         if let apiKey, !apiKey.isEmpty {
             try KeychainHelper.save(key: keychainKey(for: id), value: apiKey)
-            updateGlobalAPIKeyCache(provider: old.provider, apiKey: apiKey, baseURL: nil)
+            clearLegacyAPIKeyCache(provider: old.provider)
         }
 
-        // Update base URL cache if changed
+        // Update non-secret base URL cache if changed.
         if let baseURL {
-            updateGlobalAPIKeyCache(provider: old.provider, apiKey: nil, baseURL: baseURL)
+            updateProviderConfigCache(provider: old.provider, baseURL: baseURL)
         }
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
@@ -347,7 +351,7 @@ actor ProviderAccountService {
         // UserDefaults API key hint so the UI can surface a proper error.
         let remainingForProvider = locals.contains { $0.provider == removed.provider }
         if !remainingForProvider {
-            clearGlobalAPIKeyCache(provider: removed.provider)
+            clearProviderConfigCache(provider: removed.provider)
         }
 
         await MainActor.run { NotificationCenter.default.post(name: .providerKeysUpdated, object: nil) }
@@ -508,6 +512,76 @@ actor ProviderAccountService {
 // MARK: - ProviderAccountService Private Helpers
 
 extension ProviderAccountService {
+    /// Resolve the first configured API key for a provider from Keychain using
+    /// user-scoped account metadata. This intentionally bypasses UserDefaults
+    /// secret mirrors; UserDefaults may only contain non-secret metadata.
+    static func apiKeyFromKeychain(forProvider provider: String) -> String? {
+        let normalized = provider.lowercased()
+        let providerMatches: (String) -> Bool = { candidate in
+            let lower = candidate.lowercased()
+            if normalized == "google" || normalized == "gemini" {
+                return lower == "google" || lower == "gemini"
+            }
+            if normalized == "together" {
+                return lower == "hermes"
+            }
+            return lower == normalized
+        }
+
+        let accounts = loadLocalAccountsFromDefaults().filter { providerMatches($0.provider) }
+        guard let account = accounts.first else {
+            return nil
+        }
+        return KeychainHelper.load(key: keychainKey(forAccountId: account.id))
+    }
+
+    static func clearLegacyAPIKeyCache(provider: String) {
+        let defaults = UserDefaults.standard
+        let keys: [String]
+        switch provider.lowercased() {
+        case "openai":
+            keys = ["openai_api_key"]
+        case "anthropic":
+            keys = ["anthropic_api_key"]
+        case "google", "gemini":
+            keys = ["gemini_api_key"]
+        case "openclaw":
+            keys = ["openclaw_api_key"]
+        case "hermes", "together":
+            keys = ["hermes_api_key", "together_api_key"]
+        default:
+            keys = []
+        }
+        for key in keys {
+            defaults.removeObject(forKey: UserScope.scopedKey(key))
+        }
+    }
+
+    private static func loadLocalAccountsFromDefaults() -> [LocalProviderAccount] {
+        let storageKey = UserScope.scopedKey("provider_accounts.v1")
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else {
+            return []
+        }
+        do {
+            return try JSONDecoder().decode([LocalProviderAccount].self, from: data)
+        } catch {
+            AppErrorReporter.log(error: error, context: "ProviderAccountService.loadLocalAccountsFromDefaults.decodeAccounts")
+            return []
+        }
+    }
+
+    private static func keychainKey(forAccountId accountId: String) -> String {
+        "provider-account-\(accountId)"
+    }
+
+    private static func sanitizedHTTPError(provider: String, statusCode: Int) -> NSError {
+        NSError(
+            domain: "ProviderAccountService",
+            code: statusCode,
+            userInfo: [NSLocalizedDescriptionKey: "\(provider) models HTTP \(statusCode). Response body omitted to avoid leaking provider/account metadata."]
+        )
+    }
+
     private func loadLocalAccounts() throws -> [LocalProviderAccount] {
         let defaults = UserDefaults.standard
         guard let data = defaults.data(forKey: storageKey) else {
@@ -531,51 +605,41 @@ extension ProviderAccountService {
         "provider-account-\(accountId)"
     }
 
-    private func updateGlobalAPIKeyCache(provider: String, apiKey: String?, baseURL: String? = nil) {
+    private func updateProviderConfigCache(provider: String, baseURL: String? = nil) {
         let defaults = UserDefaults.standard
+        clearLegacyAPIKeyCache(provider: provider)
         switch provider.lowercased() {
-        case "openai":
-            if let apiKey { defaults.set(apiKey, forKey: UserScope.scopedKey("openai_api_key")) }
-        case "anthropic":
-            if let apiKey { defaults.set(apiKey, forKey: UserScope.scopedKey("anthropic_api_key")) }
-        case "google", "gemini":
-            if let apiKey { defaults.set(apiKey, forKey: UserScope.scopedKey("gemini_api_key")) }
         case "ollama":
             if let baseURL { defaults.set(baseURL, forKey: UserScope.scopedKey("ollama_base_url")) }
         case "openclaw":
-            if let apiKey { defaults.set(apiKey, forKey: UserScope.scopedKey("openclaw_api_key")) }
             if let baseURL { defaults.set(baseURL, forKey: UserScope.scopedKey("openclaw_base_url")) }
         case "hermes":
-            if let apiKey { defaults.set(apiKey, forKey: UserScope.scopedKey("hermes_api_key")) }
             if let baseURL { defaults.set(baseURL, forKey: UserScope.scopedKey("hermes_base_url")) }
         default:
             break
         }
     }
 
-    private func clearGlobalAPIKeyCache(provider: String) {
+    private func clearProviderConfigCache(provider: String) {
         let defaults = UserDefaults.standard
+        clearLegacyAPIKeyCache(provider: provider)
         switch provider.lowercased() {
-        case "openai":
-            defaults.removeObject(forKey: UserScope.scopedKey("openai_api_key"))
-        case "anthropic":
-            defaults.removeObject(forKey: UserScope.scopedKey("anthropic_api_key"))
-        case "google", "gemini":
-            defaults.removeObject(forKey: UserScope.scopedKey("gemini_api_key"))
         case "ollama":
             defaults.removeObject(forKey: UserScope.scopedKey("ollama_base_url"))
         case "mlx":
             defaults.removeObject(forKey: "MLXModelManager.activeModelID")
             defaults.removeObject(forKey: "MLXModelManager.downloadedModelIDs")
         case "openclaw":
-            defaults.removeObject(forKey: UserScope.scopedKey("openclaw_api_key"))
             defaults.removeObject(forKey: UserScope.scopedKey("openclaw_base_url"))
         case "hermes":
-            defaults.removeObject(forKey: UserScope.scopedKey("hermes_api_key"))
             defaults.removeObject(forKey: UserScope.scopedKey("hermes_base_url"))
         default:
             break
         }
+    }
+
+    private func clearLegacyAPIKeyCache(provider: String) {
+        ProviderAccountService.clearLegacyAPIKeyCache(provider: provider)
     }
 
     /// Try to fetch live model metadata for a specific provider account using
@@ -600,12 +664,7 @@ extension ProviderAccountService {
             request.setValue("application/json", forHTTPHeaderField: "Accept")
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-                let body = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-                throw NSError(
-                    domain: "ProviderAccountService",
-                    code: http.statusCode,
-                    userInfo: [NSLocalizedDescriptionKey: "OpenAI models HTTP \(http.statusCode): \(body)"]
-                )
+                throw Self.sanitizedHTTPError(provider: "OpenAI", statusCode: http.statusCode)
             }
             let decoded = try JSONDecoder().decode(OpenAIListResponse.self, from: data)
             let chatOnly = decoded.data
@@ -647,12 +706,7 @@ extension ProviderAccountService {
                 request.setValue("application/json", forHTTPHeaderField: "Accept")
                 let (data, response) = try await URLSession.shared.data(for: request)
                 if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-                    let body = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-                    throw NSError(
-                        domain: "ProviderAccountService",
-                        code: http.statusCode,
-                        userInfo: [NSLocalizedDescriptionKey: "Gemini models HTTP \(http.statusCode): \(body)"]
-                    )
+                    throw Self.sanitizedHTTPError(provider: "Gemini", statusCode: http.statusCode)
                 }
                 let decoded = try JSONDecoder().decode(GeminiListResponse.self, from: data)
                 allModelNames.append(contentsOf: (decoded.models ?? []).map(\.name))
@@ -720,12 +774,7 @@ extension ProviderAccountService {
             request.setValue("application/json", forHTTPHeaderField: "Accept")
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-                let body = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-                throw NSError(
-                    domain: "ProviderAccountService",
-                    code: http.statusCode,
-                    userInfo: [NSLocalizedDescriptionKey: "\(provider) models HTTP \(http.statusCode): \(body)"]
-                )
+                throw Self.sanitizedHTTPError(provider: provider, statusCode: http.statusCode)
             }
             let decoded = try JSONDecoder().decode(OpenAIListResponse.self, from: data)
             let chatOnly = decoded.data
@@ -758,12 +807,7 @@ extension ProviderAccountService {
             request.setValue("application/json", forHTTPHeaderField: "Accept")
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
-                let body = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
-                throw NSError(
-                    domain: "ProviderAccountService",
-                    code: http.statusCode,
-                    userInfo: [NSLocalizedDescriptionKey: "Anthropic models HTTP \(http.statusCode): \(body)"]
-                )
+                throw Self.sanitizedHTTPError(provider: "Anthropic", statusCode: http.statusCode)
             }
             let decoded = try JSONDecoder().decode(AnthropicListResponse.self, from: data)
             let modelsData = decoded.data ?? []

--- a/swift/AICoven/AICoven/Services/StoreService.swift
+++ b/swift/AICoven/AICoven/Services/StoreService.swift
@@ -46,7 +46,7 @@ class StoreService: ObservableObject {
 
     /// Whether user is authenticated. Entitlements require authentication.
     private var isAuthenticated: Bool {
-        UserScope.currentUserID != nil
+        UserScope.firebaseUserID != nil
     }
 
     var hasCreator: Bool {
@@ -116,7 +116,7 @@ class StoreService: ObservableObject {
     /// Reload entitlements for the current user. Call after user switch.
     /// Requires authentication - clears entitlements if no user is signed in.
     func reloadForCurrentUser() async {
-        let userID = UserScope.currentUserID ?? "<none>"
+        let userID = UserScope.currentUserID
         print("💳 StoreService.reloadForCurrentUser: userID=\(userID)")
 
         await MainActor.run {
@@ -124,7 +124,7 @@ class StoreService: ObservableObject {
             purchasedProductIDs = []
 
             // Only load purchases if user is authenticated
-            guard UserScope.currentUserID != nil else {
+            guard isAuthenticated else {
                 AppErrorReporter.log(message: "Clearing purchases - no authenticated user", context: "StoreService.reloadForCurrentUser")
                 return
             }
@@ -135,7 +135,7 @@ class StoreService: ObservableObject {
         }
 
         // Only refresh from StoreKit if authenticated
-        guard UserScope.currentUserID != nil else { return }
+        guard isAuthenticated else { return }
         await refreshEntitlements()
         print("💳 After StoreKit refresh: \(purchasedProductIDs)")
     }
@@ -143,7 +143,7 @@ class StoreService: ObservableObject {
     /// Clear stale test purchases that were cached for this user but made by automated tests.
     /// Call this once to clean up after running tests with a real Firebase account.
     func clearStalePurchasesForCurrentUser() {
-        guard UserScope.currentUserID != nil else { return }
+        guard isAuthenticated else { return }
         print("🧹 Clearing stale purchases for current user")
         print("   Was: \(purchasedProductIDs)")
         purchasedProductIDs = []
@@ -164,8 +164,8 @@ class StoreService: ObservableObject {
     private var transactionListenerTask: Task<Void, Never>?
 
     private init() {
-        // Don't load persisted purchases here - they're unscoped if no user is signed in.
-        // Instead, load them in reloadForCurrentUser() which is called after auth.
+        // Don't load persisted purchases here. The active user scope may change
+        // after authentication, so entitlements load in reloadForCurrentUser().
         transactionListenerTask = listenForTransactions()
         Task {
             await loadProducts()
@@ -223,7 +223,7 @@ class StoreService: ObservableObject {
         purchaseError = nil
 
         // Require authentication before allowing purchase
-        guard UserScope.currentUserID != nil else {
+        guard isAuthenticated else {
             purchaseError = "Please sign in to make a purchase."
             return
         }

--- a/swift/AICoven/AICoven/Services/ThreadInputValidator.swift
+++ b/swift/AICoven/AICoven/Services/ThreadInputValidator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Validation helpers for user-supplied thread fields.
+enum ThreadInputValidator {
+    static let maxTitleLength = 120
+
+    /// Normalize a thread title for single-line display and persistence.
+    /// Empty or whitespace-only values resolve to `defaultTitle`.
+    static func normalizedTitle(_ title: String?, defaultTitle: String) -> String {
+        guard let title else { return defaultTitle }
+
+        let collapsed = title
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        guard !collapsed.isEmpty else { return defaultTitle }
+
+        if collapsed.count <= maxTitleLength {
+            return collapsed
+        }
+
+        return String(collapsed.prefix(maxTitleLength))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/swift/AICoven/AICoven/Services/ThreadService.swift
+++ b/swift/AICoven/AICoven/Services/ThreadService.swift
@@ -18,10 +18,9 @@ actor ThreadService {
     private var persistenceURL: URL
 
     private init() {
-        // IMPORTANT: Do NOT load threads here. At init time, the Firebase user
-        // may not be authenticated yet, so UserScope.currentUserID returns nil
-        // and we'd load from the unscoped file, causing data leakage between users.
-        // Threads are loaded in reloadForCurrentUser() after authentication.
+        // IMPORTANT: Do NOT load threads here. The active user scope may change
+        // after authentication, so threads are loaded in reloadForCurrentUser()
+        // using the scoped persistence path for the current owner.
         persistenceURL = ThreadService.makePersistenceURL()
         // Start with empty array - will be populated after auth via reloadForCurrentUser()
         personalThreads = []
@@ -29,7 +28,7 @@ actor ThreadService {
 
     /// Reload threads for the current user. Call after user switch.
     func reloadForCurrentUser() {
-        let currentUID = UserScope.currentUserID ?? "<none>"
+        let currentUID = UserScope.currentUserID
         persistenceURL = ThreadService.makePersistenceURL()
         print("🔄 ThreadService.reloadForCurrentUser: currentUID=\(currentUID), file=\(persistenceURL.lastPathComponent)")
 
@@ -73,22 +72,11 @@ actor ThreadService {
     /// This handles legacy threads created before auth was required.
     private func cleanupOrphanedThreads() {
         let currentUserID = UserScope.currentUserID
-        guard let currentUserID else {
-            // No user signed in - clear all threads to prevent data leakage
-            if !personalThreads.isEmpty {
-                print("⚠️ Clearing \(personalThreads.count) threads - no authenticated user")
-                AppErrorReporter.log(message: "Clearing \(personalThreads.count) threads - no authenticated user", context: "ThreadService.cleanupOrphanedThreads")
-                personalThreads = []
-                persistPersonalThreads()
-            }
-            return
-        }
 
-        // Remove threads with missing, invalid, or mismatched user IDs
+        // Remove threads with missing or mismatched user IDs
         let validUserIDs = [currentUserID] // Only current user's threads are valid
         let orphanedThreads = personalThreads.filter { thread in
             thread.userId.isEmpty ||
-                thread.userId == "local-user" ||
                 !validUserIDs.contains(thread.userId)
         }
 
@@ -195,14 +183,8 @@ actor ThreadService {
     ///   - covenId: The coven ID (nil for personal thread)
     ///   - agentId: AI agent/role ID (optional)
     /// - Returns: The created thread
-    /// Fallback user ID for local-first mode when no Firebase user is authenticated.
-    /// This allows the app to work fully offline without requiring sign-in.
-    private static let localFallbackUserID = "local-user"
-
     func createThread(title: String? = nil, covenId: String? = nil, agentId: String? = nil, agentName: String? = nil) async throws -> Thread {
-        // Use authenticated user ID if available, otherwise fall back to local user ID.
-        // This allows the app to work in offline/local-first mode without Firebase.
-        let currentUserID = await AuthService.shared.currentUser?.id ?? Self.localFallbackUserID
+        let currentUserID = UserScope.currentUserID
 
         if let covenId {
             // Coven threads are persisted locally just like personal threads.

--- a/swift/AICoven/AICoven/Services/ThreadService.swift
+++ b/swift/AICoven/AICoven/Services/ThreadService.swift
@@ -28,15 +28,10 @@ actor ThreadService {
 
     /// Reload threads for the current user. Call after user switch.
     func reloadForCurrentUser() {
-        let currentUID = UserScope.currentUserID
         persistenceURL = ThreadService.makePersistenceURL()
-        print("🔄 ThreadService.reloadForCurrentUser: currentUID=\(currentUID), file=\(persistenceURL.lastPathComponent)")
+        AppErrorReporter.log(message: "Reloading scoped personal threads", context: "ThreadService.reloadForCurrentUser")
 
         personalThreads = ThreadService.loadThreadsFromDisk(persistenceURL: persistenceURL)
-
-        // Debug: Log user IDs of loaded threads
-        let userIDs = Set(personalThreads.map(\.userId))
-        print("📋 Loaded threads with userIDs: \(userIDs)")
 
         // Clean up any orphaned threads without a valid user ID.
         // These may exist from before authentication was required.
@@ -54,17 +49,11 @@ actor ThreadService {
         }
 
         if !testThreads.isEmpty {
-            print("🧹 Removing \(testThreads.count) test threads")
-            for thread in testThreads {
-                print("   - '\(thread.title ?? "Untitled")'")
-            }
+            AppErrorReporter.log(message: "Removing \(testThreads.count) automated test threads", context: "ThreadService.cleanupTestThreads")
             personalThreads.removeAll { thread in
                 thread.title?.hasPrefix("Test Thread") == true
             }
             persistPersonalThreads()
-            print("✅ Test threads removed. Remaining: \(personalThreads.count) threads")
-        } else {
-            print("ℹ️ No test threads found to clean up")
         }
     }
 
@@ -81,10 +70,6 @@ actor ThreadService {
         }
 
         if !orphanedThreads.isEmpty {
-            print("🧹 Removing \(orphanedThreads.count) orphaned threads (expected userId: \(currentUserID))")
-            for thread in orphanedThreads {
-                print("   - Thread '\(thread.title ?? "Untitled")' has userId: '\(thread.userId)'")
-            }
             AppErrorReporter.log(message: "Removing \(orphanedThreads.count) orphaned threads (invalid user ID)", context: "ThreadService.cleanupOrphanedThreads")
             personalThreads.removeAll { thread in
                 thread.userId.isEmpty ||
@@ -92,8 +77,6 @@ actor ThreadService {
                     !validUserIDs.contains(thread.userId)
             }
             persistPersonalThreads()
-        } else {
-            print("✅ All \(personalThreads.count) threads belong to current user")
         }
     }
 
@@ -190,11 +173,12 @@ actor ThreadService {
             // Coven threads are persisted locally just like personal threads.
             AppErrorReporter.log(message: "Creating coven thread (covenId: \(covenId)) in local store", context: "ThreadService.createThread")
             let now = Date()
+            let normalizedTitle = ThreadInputValidator.normalizedTitle(title, defaultTitle: "Coven Chat")
             let thread = await Thread(
                 id: UUID().uuidString,
                 userId: currentUserID,
                 covenId: covenId,
-                title: title ?? "Coven Chat",
+                title: normalizedTitle,
                 agentId: agentId,
                 agentName: agentName,
                 agentModel: nil,
@@ -215,11 +199,12 @@ actor ThreadService {
         } else {
             AppErrorReporter.log(message: "Creating personal thread in local store", context: "ThreadService.createThread")
             let now = Date()
+            let normalizedTitle = ThreadInputValidator.normalizedTitle(title, defaultTitle: "New Chat")
             let thread = await Thread(
                 id: UUID().uuidString,
                 userId: currentUserID,
                 covenId: nil,
-                title: title ?? "New Chat",
+                title: normalizedTitle,
                 agentId: agentId,
                 agentName: agentName,
                 agentModel: nil,
@@ -257,7 +242,7 @@ actor ThreadService {
         throw NSError(
             domain: "ThreadService",
             code: -1,
-            userInfo: [NSLocalizedDescriptionKey: "Thread not found: \(threadId)"]
+            userInfo: [NSLocalizedDescriptionKey: "Thread not found"]
         )
     }
 
@@ -294,7 +279,7 @@ actor ThreadService {
         // threads in the local-first client.
         if let index = personalThreads.firstIndex(where: { $0.id == threadId }) {
             let thread = personalThreads[index]
-            let newTitle = title ?? thread.title
+            let newTitle = title.map { ThreadInputValidator.normalizedTitle($0, defaultTitle: thread.title ?? "New Chat") } ?? thread.title
             let newAgentId = agentId ?? thread.agentId
             let newPinned = isPinned ?? thread.isPinned
             let newArchived = isArchived ?? thread.isArchived
@@ -318,9 +303,8 @@ actor ThreadService {
             return updated
         }
 
-        // If no local thread found, just return a synthesized placeholder so
-        // callers have something to work with.
-        print("📝 updateThread(\(threadId)) called for unknown thread in local-only build – returning placeholder.")
+        // If no local thread is found, throw the same sanitized not-found
+        // error as getThread(threadId:) rather than logging opaque IDs.
         return try await getThread(threadId: threadId)
     }
 
@@ -330,12 +314,12 @@ actor ThreadService {
         if let index = personalThreads.firstIndex(where: { $0.id == threadId }) {
             personalThreads.remove(at: index)
             persistPersonalThreads()
-            print("🗑️ Deleted personal thread \(threadId) from local store")
+            AppErrorReporter.log(message: "Deleted personal thread from local store", context: "ThreadService.deleteThread")
 
             // Track analytics
             await AnalyticsService.shared.trackThreadDeleted(threadId: threadId)
         } else {
-            print("🗑️ deleteThread(\(threadId)) called for unknown thread in local-only build – ignoring.")
+            AppErrorReporter.log(message: "Ignoring delete for unknown thread", context: "ThreadService.deleteThread")
         }
     }
 }

--- a/swift/AICoven/AICoven/Views/Settings/SettingsView.swift
+++ b/swift/AICoven/AICoven/Views/Settings/SettingsView.swift
@@ -10,6 +10,8 @@ struct SettingsView: View {
     @AppStorage("analytics_product_enabled") private var productAnalyticsEnabled = true
     @AppStorage("analytics_performance_enabled") private var performanceAnalyticsEnabled = true
 
+    @State private var cacheClearMessage: String?
+
     private let analytics = AnalyticsService.shared
 
     var body: some View {
@@ -143,13 +145,24 @@ struct SettingsView: View {
             .onAppear {
                 analytics.trackScreenView(screenName: "SettingsView", screenClass: "SettingsView")
             }
+            .alert(
+                "Cache Cleared",
+                isPresented: Binding(
+                    get: { cacheClearMessage != nil },
+                    set: { if !$0 { cacheClearMessage = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(cacheClearMessage ?? "")
+            }
         }
     }
 
     /// Clear cached data
     private func clearCache() {
-        // TODO: Implement cache clearing
-        print("Clearing cache...")
+        let result = CacheManagementService.clearLocalCaches()
+        cacheClearMessage = result.userMessage
     }
 
     /// Update analytics consent based on user preferences

--- a/swift/AICoven/AICovenTests/AgentRunnerToolingTests.swift
+++ b/swift/AICoven/AICovenTests/AgentRunnerToolingTests.swift
@@ -46,6 +46,7 @@ final class AgentRunnerToolingTests: XCTestCase {
     func testToolExecution_currentTimeProducesContextBlock() async {
         let mock = MockToolService()
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
 
         let call = ParsedToolCall(name: "current_time", args: [:])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
@@ -72,6 +73,7 @@ final class AgentRunnerToolingTests: XCTestCase {
         ]
 
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
         let call = ParsedToolCall(name: "web_search", args: ["query": AnyJSONValue("swift programming")])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
 
@@ -87,6 +89,7 @@ final class AgentRunnerToolingTests: XCTestCase {
         mock.webSearchResults = [] // No results
 
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
         let call = ParsedToolCall(name: "web_search", args: ["query": AnyJSONValue("xyznonexistentquery12345")])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
 
@@ -105,6 +108,7 @@ final class AgentRunnerToolingTests: XCTestCase {
         )
 
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
         let call = ParsedToolCall(name: "web_search", args: ["query": AnyJSONValue("swift programming")])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
 
@@ -117,6 +121,7 @@ final class AgentRunnerToolingTests: XCTestCase {
     func testToolExecution_webSearchMissingQueryReturnsValidationError() async {
         let mock = MockToolService()
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
 
         let call = ParsedToolCall(name: "web_search", args: [:])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
@@ -128,11 +133,24 @@ final class AgentRunnerToolingTests: XCTestCase {
     func testToolExecution_unknownToolReturnsError() async {
         let mock = MockToolService()
         let service = ToolExecutionService(toolService: mock)
+        await service.setWhitelist(for: "test-agent", tools: ["current_time", "web_search", "nonexistent_tool"])
 
         let call = ParsedToolCall(name: "nonexistent_tool", args: [:])
         let result = await service.execute(toolCall: call, agentType: "test-agent")
 
         XCTAssertEqual(result.status, "error", "Expected error status for unknown tool")
         XCTAssertTrue(result.error?.contains("Unknown tool") == true)
+    }
+
+    func testToolExecution_missingWhitelistDeniesToolByDefault() async {
+        let mock = MockToolService()
+        let service = ToolExecutionService(toolService: mock)
+
+        let call = ParsedToolCall(name: "current_time", args: [:])
+        let result = await service.execute(toolCall: call, agentType: "unconfigured-agent")
+
+        XCTAssertEqual(result.status, "denied")
+        XCTAssertEqual(result.errorType, "permission_denied")
+        XCTAssertTrue(result.error?.contains("not allowed") == true)
     }
 }

--- a/swift/AICoven/AICovenTests/CacheManagementServiceTests.swift
+++ b/swift/AICoven/AICovenTests/CacheManagementServiceTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import AICoven
+
+@MainActor
+final class CacheManagementServiceTests: XCTestCase {
+    func testClearLocalCachesDoesNotReportUserDataDeletion() {
+        let result = CacheManagementService.clearLocalCaches()
+
+        XCTAssertGreaterThanOrEqual(result.removedItems, 0)
+        XCTAssertTrue(result.userMessage.contains("chats") || result.userMessage.contains("No cached files"))
+        XCTAssertTrue(result.userMessage.contains("provider keys") || result.userMessage.contains("No cached files"))
+    }
+
+    func testPricingCacheClearRemovesFetchMarker() {
+        UserDefaults.standard.set(Date(), forKey: "model_pricing.last_fetched")
+
+        let removedItems = PricingUpdateService.shared.clearCachedOverrides()
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: "model_pricing.last_fetched"))
+        XCTAssertGreaterThanOrEqual(removedItems, 1)
+    }
+}

--- a/swift/AICoven/AICovenTests/DatabaseSchemaSecurityTests.swift
+++ b/swift/AICoven/AICovenTests/DatabaseSchemaSecurityTests.swift
@@ -1,0 +1,67 @@
+import GRDB
+import XCTest
+@testable import AICoven
+
+@MainActor
+final class DatabaseSchemaSecurityTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        DatabaseManager.shared.configureIfNeeded()
+    }
+
+    func testUserScopedTablesRejectMissingUserID() async throws {
+        let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
+
+        XCTAssertThrowsError(try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO threads (id, title, created_at, user_id) VALUES (?, ?, ?, NULL)",
+                arguments: ["phase2-null-thread-\(UUID().uuidString)", "Null user", Date()]
+            )
+        })
+
+        XCTAssertThrowsError(try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO memory_chunks (id, scope, pii_flag, created_at, text_ciphertext, user_id) VALUES (?, ?, ?, ?, ?, '')",
+                arguments: ["phase2-null-memory-\(UUID().uuidString)", "test", false, Date(), Data("secret".utf8)]
+            )
+        })
+    }
+
+    func testMessagesMustBelongToSameUserAsThread() async throws {
+        let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
+        let threadID = "phase2-thread-\(UUID().uuidString)"
+
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO threads (id, title, created_at, user_id) VALUES (?, ?, ?, ?)",
+                arguments: [threadID, "Owner thread", Date(), "owner-a"]
+            )
+        }
+
+        XCTAssertThrowsError(try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO messages (id, thread_id, role, created_at, content_ciphertext, user_id) VALUES (?, ?, ?, ?, ?, ?)",
+                arguments: ["phase2-message-\(UUID().uuidString)", threadID, "user", Date(), Data("hello".utf8), "owner-b"]
+            )
+        })
+    }
+
+    func testRolesMustBelongToSameUserAsCoven() async throws {
+        let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
+        let covenID = "phase2-coven-\(UUID().uuidString)"
+
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO covens (id, name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?)",
+                arguments: [covenID, "Owner coven", Date(), Date(), "owner-a"]
+            )
+        }
+
+        XCTAssertThrowsError(try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO roles (id, coven_id, name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?, ?)",
+                arguments: ["phase2-role-\(UUID().uuidString)", covenID, "Role", Date(), Date(), "owner-b"]
+            )
+        })
+    }
+}

--- a/swift/AICoven/AICovenTests/DatabaseSchemaSecurityTests.swift
+++ b/swift/AICoven/AICovenTests/DatabaseSchemaSecurityTests.swift
@@ -9,7 +9,7 @@ final class DatabaseSchemaSecurityTests: XCTestCase {
         DatabaseManager.shared.configureIfNeeded()
     }
 
-    func testUserScopedTablesRejectMissingUserID() async throws {
+    func testUserScopedTablesRejectMissingUserID() throws {
         let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
 
         XCTAssertThrowsError(try dbQueue.write { db in
@@ -27,7 +27,7 @@ final class DatabaseSchemaSecurityTests: XCTestCase {
         })
     }
 
-    func testMessagesMustBelongToSameUserAsThread() async throws {
+    func testMessagesMustBelongToSameUserAsThread() throws {
         let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
         let threadID = "phase2-thread-\(UUID().uuidString)"
 
@@ -46,7 +46,7 @@ final class DatabaseSchemaSecurityTests: XCTestCase {
         })
     }
 
-    func testRolesMustBelongToSameUserAsCoven() async throws {
+    func testRolesMustBelongToSameUserAsCoven() throws {
         let dbQueue = try XCTUnwrap(DatabaseManager.shared.dbQueue)
         let covenID = "phase2-coven-\(UUID().uuidString)"
 

--- a/swift/AICoven/AICovenTests/ErrorReportingTests.swift
+++ b/swift/AICoven/AICovenTests/ErrorReportingTests.swift
@@ -152,12 +152,12 @@ final class ErrorReportingTests: XCTestCase {
     }
 
     func testLogRedactorRedactsSecretsAndPersonalIdentifiers() {
-        let input = "email person@example.com api_key=sk-test_abcdefghijklmnopqrstuvwxyz userId: firebase-user-1234567890abcdef"
+        let input = "email person@example.com api_key=sample-secret-value userId: firebase-user-1234567890abcdef"
 
         let redacted = AppLogRedactor.redact(input)
 
         XCTAssertFalse(redacted.contains("person@example.com"))
-        XCTAssertFalse(redacted.contains("sk-test_abcdefghijklmnopqrstuvwxyz"))
+        XCTAssertFalse(redacted.contains("sample-secret-value"))
         XCTAssertFalse(redacted.contains("firebase-user-1234567890abcdef"))
         XCTAssertTrue(redacted.contains("<redacted>"))
     }

--- a/swift/AICoven/AICovenTests/ErrorReportingTests.swift
+++ b/swift/AICoven/AICovenTests/ErrorReportingTests.swift
@@ -150,4 +150,30 @@ final class ErrorReportingTests: XCTestCase {
         // No assertion here because the test is verifying code structure, not
         // runtime behavior.
     }
+
+    func testLogRedactorRedactsSecretsAndPersonalIdentifiers() {
+        let input = "email person@example.com api_key=sk-test_abcdefghijklmnopqrstuvwxyz userId: firebase-user-1234567890abcdef"
+
+        let redacted = AppLogRedactor.redact(input)
+
+        XCTAssertFalse(redacted.contains("person@example.com"))
+        XCTAssertFalse(redacted.contains("sk-test_abcdefghijklmnopqrstuvwxyz"))
+        XCTAssertFalse(redacted.contains("firebase-user-1234567890abcdef"))
+        XCTAssertTrue(redacted.contains("<redacted>"))
+    }
+
+    func testAppErrorReporterPassesRedactedMessagesToReporter() {
+        let reporter = CapturingErrorReporter()
+        AppErrorReporter.use(reporter)
+
+        AppErrorReporter.log(
+            message: "Failed for userId=abc123456789abcdef and token=secret-token-value",
+            context: "Auth.email.person@example.com"
+        )
+
+        XCTAssertEqual(reporter.messages.count, 1)
+        XCTAssertFalse(reporter.messages[0].message.contains("abc123456789abcdef"))
+        XCTAssertFalse(reporter.messages[0].message.contains("secret-token-value"))
+        XCTAssertFalse(reporter.messages[0].context.contains("person@example.com"))
+    }
 }

--- a/swift/AICoven/AICovenTests/HermesLLMClientTests.swift
+++ b/swift/AICoven/AICovenTests/HermesLLMClientTests.swift
@@ -121,7 +121,9 @@ final class HermesLLMClientTests: XCTestCase {
         } catch {
             let nsError = error as NSError
             XCTAssertEqual(nsError.code, 401)
-            XCTAssertTrue(nsError.localizedDescription.contains("Invalid API key"))
+            XCTAssertTrue(nsError.localizedDescription.contains("Hermes HTTP 401"))
+            XCTAssertFalse(nsError.localizedDescription.contains("Invalid API key"))
+            XCTAssertTrue(nsError.localizedDescription.contains("Response body omitted"))
         }
     }
 

--- a/swift/AICoven/AICovenTests/OpenClawLLMClientTests.swift
+++ b/swift/AICoven/AICovenTests/OpenClawLLMClientTests.swift
@@ -120,7 +120,9 @@ final class OpenClawLLMClientTests: XCTestCase {
         } catch {
             let nsError = error as NSError
             XCTAssertEqual(nsError.code, 400)
-            XCTAssertTrue(nsError.localizedDescription.contains("Invalid request"))
+            XCTAssertTrue(nsError.localizedDescription.contains("OpenClaw HTTP 400"))
+            XCTAssertFalse(nsError.localizedDescription.contains("Invalid request"))
+            XCTAssertTrue(nsError.localizedDescription.contains("Response body omitted"))
         }
     }
 }

--- a/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
+++ b/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
@@ -8,6 +8,8 @@ final class ProviderCredentialStorageTests: XCTestCase {
         for key in ["openai_api_key", "anthropic_api_key", "gemini_api_key", "openclaw_api_key", "hermes_api_key", "together_api_key"] {
             defaults.removeObject(forKey: UserScope.scopedKey(key))
         }
+        KeychainHelper.delete(key: "provider-account-hermes-test")
+        KeychainHelper.delete(key: "provider-account-together-test")
         super.tearDown()
     }
 
@@ -40,5 +42,49 @@ final class ProviderCredentialStorageTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("openclaw_api_key")))
         XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("hermes_api_key")))
         XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("together_api_key")))
+    }
+
+    func testHermesTogetherProviderAliasesResolveBidirectionallyFromKeychain() throws {
+        let defaults = UserDefaults.standard
+        let now = Date()
+        let hermesAccount = LocalProviderAccount(
+            id: "hermes-test",
+            provider: "hermes",
+            displayName: "Hermes",
+            scopes: ["chat"],
+            defaultModel: nil,
+            baseURL: nil,
+            status: "healthy",
+            createdAt: now
+        )
+        let togetherAccount = LocalProviderAccount(
+            id: "together-test",
+            provider: "together",
+            displayName: "Together",
+            scopes: ["chat"],
+            defaultModel: nil,
+            baseURL: nil,
+            status: "healthy",
+            createdAt: now
+        )
+
+        try KeychainHelper.save(key: "provider-account-hermes-test", value: "HERMES_KEY")
+        try KeychainHelper.save(key: "provider-account-together-test", value: "TOGETHER_KEY")
+
+        defaults.set(try JSONEncoder().encode([hermesAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
+        XCTAssertEqual(ProviderAccountService.apiKeyFromKeychain(forProvider: "together"), "HERMES_KEY")
+
+        defaults.set(try JSONEncoder().encode([togetherAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
+        XCTAssertEqual(ProviderAccountService.apiKeyFromKeychain(forProvider: "hermes"), "TOGETHER_KEY")
+    }
+
+    func testProviderSpecificMissingKeyErrorDescriptionsAreNotOpenAISpecific() {
+        let anthropicDescription = LocalChatError.missingAPIKey(provider: "Anthropic").localizedDescription
+        let geminiDescription = LocalChatError.missingAPIKey(provider: "Gemini").localizedDescription
+
+        XCTAssertTrue(anthropicDescription.contains("Anthropic"))
+        XCTAssertTrue(geminiDescription.contains("Gemini"))
+        XCTAssertFalse(anthropicDescription.contains("OpenAI"))
+        XCTAssertFalse(geminiDescription.contains("OpenAI"))
     }
 }

--- a/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
+++ b/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import AICoven
+
+final class ProviderCredentialStorageTests: XCTestCase {
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: UserScope.scopedKey("provider_accounts.v1"))
+        for key in ["openai_api_key", "anthropic_api_key", "gemini_api_key", "openclaw_api_key", "hermes_api_key", "together_api_key"] {
+            defaults.removeObject(forKey: UserScope.scopedKey(key))
+        }
+        super.tearDown()
+    }
+
+    func testLLMConfigurationIgnoresLegacyUserDefaultsAPIKeyMirrors() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: UserScope.scopedKey("provider_accounts.v1"))
+        defaults.set("PLAINTEXT_LEGACY_KEY", forKey: UserScope.scopedKey("openai_api_key"))
+
+        let clients = LLMConfiguration.makeDefaultClients()
+
+        XCTAssertNil(clients["openai"], "Raw API keys in UserDefaults must not configure LLM clients")
+    }
+
+    func testClearLegacyAPIKeyCacheRemovesKnownSecretMirrors() {
+        let defaults = UserDefaults.standard
+        defaults.set("OPENAI", forKey: UserScope.scopedKey("openai_api_key"))
+        defaults.set("ANTHROPIC", forKey: UserScope.scopedKey("anthropic_api_key"))
+        defaults.set("GEMINI", forKey: UserScope.scopedKey("gemini_api_key"))
+        defaults.set("OPENCLAW", forKey: UserScope.scopedKey("openclaw_api_key"))
+        defaults.set("HERMES", forKey: UserScope.scopedKey("hermes_api_key"))
+        defaults.set("TOGETHER", forKey: UserScope.scopedKey("together_api_key"))
+
+        for provider in ["openai", "anthropic", "gemini", "openclaw", "hermes"] {
+            ProviderAccountService.clearLegacyAPIKeyCache(provider: provider)
+        }
+
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("openai_api_key")))
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("anthropic_api_key")))
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("gemini_api_key")))
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("openclaw_api_key")))
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("hermes_api_key")))
+        XCTAssertNil(defaults.string(forKey: UserScope.scopedKey("together_api_key")))
+    }
+}

--- a/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
+++ b/swift/AICoven/AICovenTests/ProviderCredentialStorageTests.swift
@@ -71,10 +71,10 @@ final class ProviderCredentialStorageTests: XCTestCase {
         try KeychainHelper.save(key: "provider-account-hermes-test", value: "HERMES_KEY")
         try KeychainHelper.save(key: "provider-account-together-test", value: "TOGETHER_KEY")
 
-        defaults.set(try JSONEncoder().encode([hermesAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
+        try defaults.set(JSONEncoder().encode([hermesAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
         XCTAssertEqual(ProviderAccountService.apiKeyFromKeychain(forProvider: "together"), "HERMES_KEY")
 
-        defaults.set(try JSONEncoder().encode([togetherAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
+        try defaults.set(JSONEncoder().encode([togetherAccount]), forKey: UserScope.scopedKey("provider_accounts.v1"))
         XCTAssertEqual(ProviderAccountService.apiKeyFromKeychain(forProvider: "hermes"), "TOGETHER_KEY")
     }
 

--- a/swift/AICoven/AICovenTests/ShellToolServiceSecurityTests.swift
+++ b/swift/AICoven/AICovenTests/ShellToolServiceSecurityTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import AICoven
+
+final class ShellToolServiceSecurityTests: XCTestCase {
+    func testShellExecute_requiresExplicitWorkingDirectory() async {
+        let result = await ShellToolService.shared.execute(
+            command: "pwd",
+            workingDir: nil,
+            timeoutSeconds: 1
+        )
+
+        XCTAssertEqual(result.status, "denied")
+        XCTAssertEqual(result.errorType, "permission_denied")
+        XCTAssertTrue(result.error?.contains("explicit working directory") == true)
+    }
+
+    func testShellExecute_rejectsEmptyWorkingDirectory() async {
+        let result = await ShellToolService.shared.execute(
+            command: "pwd",
+            workingDir: "   ",
+            timeoutSeconds: 1
+        )
+
+        XCTAssertEqual(result.status, "denied")
+        XCTAssertEqual(result.errorType, "permission_denied")
+        XCTAssertTrue(result.error?.contains("explicit working directory") == true)
+    }
+}

--- a/swift/AICoven/AICovenTests/ThreadServiceTests.swift
+++ b/swift/AICoven/AICovenTests/ThreadServiceTests.swift
@@ -48,4 +48,33 @@ final class ThreadServiceTests: XCTestCase {
         let afterDelete = try await service.loadThreads(covenId: nil)
         XCTAssertFalse(afterDelete.contains(where: { $0.id == original.id }))
     }
+
+    func testThreadTitlesAreNormalizedOnCreateAndUpdate() async throws {
+        let service = ThreadService.shared
+        let longTitle = "  First line\n\nSecond line   " + String(repeating: "x", count: 200)
+
+        let created = try await service.createThread(title: longTitle, covenId: nil, agentId: nil)
+
+        XCTAssertFalse(created.title?.contains("\n") ?? true)
+        XCTAssertLessThanOrEqual(created.title?.count ?? 0, ThreadInputValidator.maxTitleLength)
+        XCTAssertTrue(created.title?.hasPrefix("First line Second line") == true)
+
+        let unchanged = try await service.updateThread(threadId: created.id, title: "   \n  ")
+        XCTAssertEqual(unchanged.title, created.title)
+
+        try await service.deleteThread(threadId: created.id)
+    }
+
+    func testMissingThreadErrorDoesNotExposeOpaqueThreadID() async {
+        let service = ThreadService.shared
+        let missingID = "thread-1234567890abcdef"
+
+        do {
+            _ = try await service.getThread(threadId: missingID)
+            XCTFail("Expected missing thread lookup to throw")
+        } catch {
+            XCTAssertFalse(error.localizedDescription.contains(missingID))
+            XCTAssertEqual(error.localizedDescription, "Thread not found")
+        }
+    }
 }

--- a/swift/AICoven/AICovenTests/UserScopeSecurityTests.swift
+++ b/swift/AICoven/AICovenTests/UserScopeSecurityTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import AICoven
+
+final class UserScopeSecurityTests: XCTestCase {
+    func testScopedKeysUseExplicitLocalOwnerWhenFirebaseIsUnavailable() {
+        XCTAssertEqual(UserScope.currentUserID, UserScope.firebaseUserID ?? UserScope.localUserID)
+        XCTAssertEqual(UserScope.scopedKey("provider_accounts.v1"), "\(UserScope.currentUserID).provider_accounts.v1")
+        XCTAssertEqual(UserScope.scopedKeychainService("AICovenProviderKeys"), "AICovenProviderKeys.\(UserScope.currentUserID)")
+        XCTAssertEqual(UserScope.scopedFilename("personal_threads", extension: "json"), "personal_threads_\(UserScope.currentUserID).json")
+    }
+
+    func testScopedKeysNeverFallBackToUnscopedBaseNames() {
+        XCTAssertNotEqual(UserScope.scopedKey("provider_accounts.v1"), "provider_accounts.v1")
+        XCTAssertNotEqual(UserScope.scopedKeychainService("AICovenProviderKeys"), "AICovenProviderKeys")
+        XCTAssertNotEqual(UserScope.scopedFilename("personal_threads", extension: "json"), "personal_threads.json")
+    }
+}


### PR DESCRIPTION
## Summary
- remove plaintext provider API key mirrors from UserDefaults and resolve provider secrets from Keychain metadata
- add PBKDF2-HMAC-SHA256 wrapping-key derivation with legacy HKDF migration and secure random generation checks
- switch tool execution to deny-by-default, configure chat/agent whitelists from enabled tool config, and require authorized shell working directories
- sanitize provider/OAuth/tool HTTP error bodies to avoid leaking account metadata
- add tests covering credential storage and tool/shell security defaults

## Verification
- git diff --check
- command -v swift / xcodebuild (not available in this Linux environment; Xcode tests not runnable here)

## Notes
This repo checkout does not include an Xcode project/workspace or SwiftPM manifest, so I could not run XCTest on this Linux VM.